### PR TITLE
Refactor config for new meteo variables and hourly aggregation

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -4,15 +4,11 @@ password = passpass
 host = localhost
 port = 3306
 database = sni
-columns_list = SO2,NO,NO2,NOX,FP1,FP2_5,FP10,WIND_SPEED,WIND_ANGLE,T,H2O,P,RAIN_MINUTE,RAIN_HOUR,RAIN_DAY,RAIN_TOTAL,SUN_RAD,T_ROOM,HUM_ROOM
-DATA_COLUMNS_BG = SO2,NO,NO2,NOX,ФПЧ1,ФПЧ2.5,ФПЧ10,Скорост на вятъра,Посока на вятъра,Температура,Относителна влажност,Атмосферно налягане,Валежи на минута,Валежи на час,Валежи на ден,Валежи общо,Слънчева радиация,Температура в станцията,Относителна влажност в станцията
+columns_list = T_AIR,T_INSIDE,REL_HUM,RADIATION,EVAPOR_MINUTE,WIND_SPEED_1,WIND_SPEED_2,WIND_DIR,WIND_GUST,P_ABS,P_REL,RAIN_MINUTE,RAIN_HOUR,T_WATER
+DATA_COLUMNS_BG = Температура - външна,Температура - вътрешна,Относителна влажност на въздуха,Глобална радиация,Изпарение - минутно,Скорост на вятъра 1,Скорост на вятъра 2,Посока на вятъра,Порив на вятъра,Налягане - абсолютно,Налягане - относително,Дъжд за минута,Дъжд за час,Температура - вода
 DATA_COLUMNS_STATUS_BG = Анализатор SO2 Грешка,Анализатор NOx Грешка,Прахомер Грешка,Метеостанция Грешка,Висока температура в помещението,Дим в помещението,Отворена врата 1,Отворена врата 2,Отпаднало захранване
 columns_list_status = SYSTEM_GASANALYSER_FAULT_1,SYSTEM_GASANALYSER_FAULT_2,SYSTEM_GASANALYSER_FAULT_3,SYSTEM_GASANALYSER_FAULT_4,HIGH_TEMP,FIRE_ALARM,DOOR1_OP,DOOR2_OP,POWER_BAD
-columns_units_list = µg/m³,µg/m³,µg/m³,µg/m³,µg/m³,µg/m³,µg/m³,m/s,°,°C,%%,hPa,mm,mm,mm,mm,W/m2,°C,%%
-nde_all = 350,200,200,200,50,50,50,,,,,,,,,
-flow_col_name = Deb
-first_pollutant_col_name = SO2
-last_pollutant_col_name = CO
+columns_units_list = °C,°C,%,W/m²,mm/min,km/h,m/s,DEG,km/h,hPa,hPa,mm,mm/h,°C
 DB_TABLE_MIN = raw_1min
 mean_1hour_table = mean_1hour
 pril_b_day_table = pril_b_day
@@ -25,17 +21,6 @@ port = 43306
 database = lcp
 table = IAOStable
 columns_list = DateRef, SO2,NO,NO2,NOX,FP1,FP2_5,FP10, O2, TempG, PreG, Deb
-
-[NDE]
-pollutants_all = SO2,NO,NO2,NOX,FP1,FP2_5,FP10
-nde_all = 350,200,200,200,50,50,50
-pollutants_units_list = µg/m³,µg/m³,µg/m³,µg/m³,µg/m³,µg/m³,µg/m³
-simple_parameters = WIND_SPEED
-#,WIND_ANGLE,T,H2O,P,RAIN_HOUR,SUN_RAD,T_ROOM,HUM_ROOM
-simple_parameters_units = m/s
-#,°,°C,%%,hPa,mm,W/m2,°C,%%
-simple_parameters_BG = Скорост на вятъра
-#,Посока на вятъра,Температура,Относителна влажност,Атмосферно налягане,Валежи на час,Слънчева радиация,Температура в станцията,Относителна влажност в станцията
 
 [EXCEL]
 str_protokol_folder = D:\Rabota\MobileAirQuality\Protokoli\
@@ -58,6 +43,6 @@ ftp_username = admin
 ftp_password = wago
 remote_csv_path = /media/sd/CSV_Files
 csv_template_name= data_dp_
-csv_col_names=Time,SO2[ug/m3],NO[ug/m3],NO2[ug/m3],NOX[ug/m3],FP1[ug/m3],FP2_5[ug/m3],FP10[ug/m3],WIND_SPEED[m/s],WIND_ANGLE[o],T[oC],H2O,P[hPa],RAIN_MINUTE[mm],RAIN_HOUR[mm],RAIN_DAY[mm],RAIN_TOTAL[mm],SUN_RAD[W/m2],T_ROOM[oC],HUM_ROOM,Fault_NO,Fault_SO2,Fault_PM,Fault_Meteo,HIGH_TEMP,FIRE_ALARM,DOOR1_OP,DOOR2_OP,POWER_BAD
-db_col_names=DateRef,SO2,NO,NO2,NOX,FP1,FP2_5,FP10,WIND_SPEED,WIND_ANGLE,T,H2O,P,RAIN_MINUTE,RAIN_HOUR,RAIN_DAY,RAIN_TOTAL,SUN_RAD,T_ROOM,HUM_ROOM,SYSTEM_GASANALYSER_FAULT_1,SYSTEM_GASANALYSER_FAULT_2,SYSTEM_GASANALYSER_FAULT_3,SYSTEM_GASANALYSER_FAULT_4,HIGH_TEMP,FIRE_ALARM,DOOR1_OP,DOOR2_OP,POWER_BAD
+csv_col_names=Time,T_AIR,T_INSIDE,REL_HUM,RADIATION,EVAPOR_MINUTE,WIND_SPEED_1,WIND_SPEED_2,WIND_DIR,WIND_GUST,P_ABS,P_REL,RAIN_MINUTE,RAIN_HOUR,T_WATER
+db_col_names=DateRef,T_AIR,T_INSIDE,REL_HUM,RADIATION,EVAPOR_MINUTE,WIND_SPEED_1,WIND_SPEED_2,WIND_DIR,WIND_GUST,P_ABS,P_REL,RAIN_MINUTE,RAIN_HOUR,T_WATER
 local_csv_folder = ./downloaded_csvs  # Local folder for saving downloaded files

--- a/insertMissingDataFromCSV.py
+++ b/insertMissingDataFromCSV.py
@@ -39,7 +39,7 @@ def read_config():
     global DB_TABLE_HOUR
     # Load configuration from config.ini
     with open('config.ini', 'r', encoding='utf-8') as config_file:
-        config = configparser.ConfigParser()
+        config = configparser.ConfigParser(interpolation=None)
         config.read_file(config_file)
 
     # Read database config

--- a/mean_1h.py
+++ b/mean_1h.py
@@ -32,7 +32,7 @@ logger = setup_logger(log_filename)
 
 # Load configuration from config.ini
 with open('config.ini', 'r', encoding='utf-8') as config_file:
-    config = configparser.ConfigParser()
+    config = configparser.ConfigParser(interpolation=None)
     config.read_file(config_file)
 
 # Get the column names as a comma-separated string from the INI file


### PR DESCRIPTION
## Summary
- trim config and CSV mappings to raw meteo fields only
- derive rain/evaporation totals in web dataframes instead of storing in database
- drop cumulative-column generation during CSV ingestion
- disable config interpolation so unit strings with % are parsed correctly

## Testing
- `python -m py_compile app.py insertMissingDataFromCSV.py mean_1h.py`


------
https://chatgpt.com/codex/tasks/task_e_68a7189e33808328befad5acced57efa