### PR TITLE
Simplify dashboard to last-minute data only

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -83,15 +83,13 @@ body {
   box-sizing: border-box; /* Prevent elements from going out of bounds */
 }
 
-/* Ensure the plot containers act as relative positioning contexts */
-#last-24-hours-plot, #last-hour-values-plot {
-  position: relative; /* Required for child elements with absolute positioning */
-  max-width: 100%; /* Ensure they don’t exceed the container width */
-  min-height: 400px; /* Ensure sufficient height for loading messages */
-  box-sizing: border-box; /* Include padding and border in size calculation */
-  overflow: hidden; /* Prevent content overflow */
-  text-align: center !important;
-  border: 1px solid #ccc; /* Optional: Add a border for better visibility */
+/* Group container for last minute data */
+.dashboard-group {
+  margin-bottom: 20px;
+}
+
+.dashboard-group h3 {
+  margin: 10px 0;
 }
 
 /* Fix for dashboard grid */
@@ -375,10 +373,6 @@ button:hover {
   .dashboard-item {
     width: 100%; /* Ensure full width for all items */
     margin: 5px 0; /* Consistent margin on smaller screens */
-  }
-   #last-24-hours-plot {
-    width: 100%; /* Ensure the plot doesn’t overflow horizontally */
-    max-width: 100%;
   }
 }
 

--- a/static/js/scripts.js
+++ b/static/js/scripts.js
@@ -1,36 +1,9 @@
 $(document).ready(function () {
-    
-    function updateLast24HoursPlots(plotsJson) {
-        const container = $('#last-24-hours-plot');
-        const loadingMessage = $('#loading-message-24');
-        const container1 = $('#last-hour-values-plot');
-        const loadingMessage1 = $('#loading-message-hour');
 
-        // Show the loading message
-        loadingMessage.show();
-        container.empty(); // Clear old plots
+    function renderDashboard(data, columnOrder, columnUnits, columnNamesBG) {
+        const container = $('#last-min-values-dashboard');
+        container.empty();
 
-        // Render each plot from JSON
-        setTimeout(() => {
-            plotsJson.forEach(plotJson => {
-                let plotData = JSON.parse(plotJson); // Parse JSON to get the Plotly figure
-
-                let div = $('<div>'); // Create a div for each plot
-                container.append(div);
-
-                Plotly.newPlot(div[0], plotData.data, plotData.layout, {responsive:false, staticPlot: true,}); // Render the plot
-            });
-
-            // Hide the loading message once the plots are rendered
-            loadingMessage.hide();
-            loadingMessage1.hide();
-        }, 500); // Small delay for smoother UI
-    }
-    function renderDashboard(data, containerId, columnOrder, columnUnits, columnNamesBG) {
-        const container = $(`#${containerId}`);
-        container.empty(); // Clear existing content
-
-        // Thresholds for individual columns
         const thresholds = {
             "SO2": [
                 { max: 300, color: 'MediumSeaGreen', textColor: 'black' },
@@ -112,199 +85,83 @@ $(document).ready(function () {
                 { max: 0.016, color: 'yellow', textColor: 'black' },
                 { max: Infinity, color: 'red', textColor: 'black' }
             ]
-            // Add more columns as needed
         };
-        // Define excluded columns for specific dashboards
-        const excludedColumns = {
-            'last-min-values-dashboard': ['RAIN_HOUR', 'RAIN_DAY', 'RAIN_TOTAL'],
-            'last-hour-values-dashboard': ['RAIN_MINUTE', 'RAIN_DAY', 'RAIN_TOTAL']
+
+        const columnGroups = {
+            'Общи параметри на въздуха': ['DateRef', 'T_AIR', 'T_INSIDE', 'REL_HUM', 'T_WATER'],
+            'Параметри на радиация': ['RADIATION'],
+            'Изпарение': ['EVAPOR_MINUTE', 'EVAPOR_DAY'],
+            'Параметри на вятъра': ['WIND_SPEED_1', 'WIND_SPEED_2', 'WIND_DIR', 'WIND_GUST'],
+            'Атмосферно налягане': ['P_ABS', 'P_REL'],
+            'Статистика за валежи': ['RAIN_MINUTE', 'RAIN_HOUR', 'RAIN_DAY', 'RAIN_MONTH', 'RAIN_YEAR']
         };
-        // Ensure 'DateRef' is always first, followed by the provided column order
-        const orderedKeys = ['DateRef', ...columnOrder.filter(col => col !== 'DateRef')];
 
-        orderedKeys.forEach((key) => {
-            // Skip excluded columns for the current dashboard
-            if (excludedColumns[containerId] && excludedColumns[containerId].includes(key)) {
-                return;
-            }
-            if (key in data) { // Ensure the key exists in the data
-                // Select appropriate Bulgarian column names based on containerId
-                const displayName =
-                    key === 'DateRef'
-                        ? 'Дата и час на записа' // Keep DateRef unchanged
-                        : columnNamesBG[columnOrder.indexOf(key)] || key; // Use Bulgarian name if available
+        Object.entries(columnGroups).forEach(([groupName, keys]) => {
+            const groupDiv = $('<div>').addClass('dashboard-group');
+            groupDiv.append(`<h3>${groupName}</h3>`);
+            const groupGrid = $('<div>').addClass('dashboard-grid');
 
-                // Units logic (skip for specific dashboards or DateRef)
-                const unit =
-                    key === 'DateRef'
-                        ? ''
-                        : columnUnits[columnOrder.indexOf(key)] || '';
+            keys.forEach(key => {
+                if (!(key in data)) return;
 
-                // Determine background color based on value and thresholds
-                let dashboardItemStyle = 'background-color: Gainsboro; color: black;'; // Default to green if no threshold exists
+                const displayName = key === 'DateRef'
+                    ? 'Дата и час на записа'
+                    : columnNamesBG[columnOrder.indexOf(key)] || key;
+                const unit = key === 'DateRef' ? '' : columnUnits[columnOrder.indexOf(key)] || '';
+
+                let style = 'background-color: Gainsboro; color: black;';
                 const value = data[key];
-                let maxThreshold = ''; // To store the max threshold for display
+                let maxThreshold = '';
 
-                if (!isNaN(value) && key in thresholds) { // Only apply color logic if the value is numeric and thresholds exist
-                    const columnThresholds = thresholds[key];
-                    const threshold = columnThresholds.find(t => value <= t.max);
+                if (!isNaN(value) && thresholds[key]) {
+                    const threshold = thresholds[key].find(t => value <= t.max);
                     if (threshold) {
-                        dashboardItemStyle = `background-color: ${threshold.color}; color: ${threshold.textColor};`;
-
-                        // Only set maxThreshold if it's for values dashboard
-                        if (containerId === 'last-min-values-dashboard' || containerId === 'last-hour-values-dashboard') {
-                            maxThreshold = columnThresholds[1].max; // Get the second threshold for НДЕ
-                        }
+                        style = `background-color: ${threshold.color}; color: ${threshold.textColor};`;
+                        maxThreshold = thresholds[key][1]?.max;
                     }
                 }
 
-                // Dashboard item HTML
                 const dashboardItem = `
-                    <div class="dashboard-item" style="${dashboardItemStyle}">
-                        <div class="variable-name">${displayName} ${unit ? `[${unit}]` : ''}</div> <!-- Line 1 -->
-                        <div class="variable-value">${value}</div> <!-- Line 2 -->
-                        ${maxThreshold && (containerId === 'last-min-values-dashboard' || containerId === 'last-hour-values-dashboard')
-                            ? `<div class="variable-threshold">ПДК: ${maxThreshold}</div>`
-                            : ''} <!-- Line 3 (only for last-min-values-dashboard and last-hour-values-dashboard) -->
+                    <div class="dashboard-item" style="${style}">
+                        <div class="variable-name">${displayName} ${unit ? `[${unit}]` : ''}</div>
+                        <div class="variable-value">${value}</div>
+                        ${maxThreshold ? `<div class="variable-threshold">ПДК: ${maxThreshold}</div>` : ''}
                     </div>
                 `;
-                container.append(dashboardItem);
-            }
+                groupGrid.append(dashboardItem);
+            });
+
+            groupDiv.append(groupGrid);
+            container.append(groupDiv);
         });
     }
 
-
-    let isFirstLoad = true; // Flag to track if it's the first data load
-    let lastHourUpdated = null; // Tracks the last hour that was updated
-    let isFetching = false; // Prevent overlapping fetches
-    let fetchInterval;
-
-    function startFetchInterval() {
-        if (fetchInterval) {
-            clearInterval(fetchInterval);
-        }
-        fetchInterval = setInterval(() => fetchMomentData('last_minute'), 60000); // Fetch every minute for last_minute data
-    }
-
-    function getCurrentHour() {
-        const now = new Date();
-        return now.getHours();
-    }
-
-    function fetchMomentData(updateType) {
-        // Validate updateType
-        if (!['last_minute', 'hourly'].includes(updateType)) {
-            console.error(`Invalid updateType passed: ${updateType}`);
-            return;
-        }
-
-        // Show loading message on first load for 'last_minute'
-        if (isFirstLoad && updateType === 'last_minute') {
-            //$('#loading-message-hour').show();
-            $('#loading-message-24').show();
-        }
-
-        // Perform AJAX GET request
+    function fetchMomentData() {
         $.ajax({
             type: 'GET',
-            url: `/moment_data?update_type=${updateType}`, // Query parameter for update type
+            url: '/moment_data?update_type=last_minute',
             cache: false,
             success: function (response) {
-                // Hide loading message on first load for 'hourly'
-                if (isFirstLoad && updateType === 'hourly') {
-                    $('#loading-message-24').hide();
-                    //$('#loading-message-hour').hide();
-                }
-
-                // Handle response errors
                 if (response.error) {
                     console.error("Error in API response:", response.error);
                     return;
                 }
-
-                // Handle 'last_minute' updates
-                if (updateType === 'last_minute') {
-                    if (response.min_values_data && response.min_values_data.length > 0) {
-                        renderDashboard(
-                            response.min_values_data[0],
-                            'last-min-values-dashboard',
-                            response.columns_values,
-                            response.columns_units,
-                            response.columns_bg
-                        );
-                    }
-                }
-
-                // Handle 'hourly' updates
-                else if (updateType === 'hourly') {
-                    const currentHour = getCurrentHour();
-
-                    // Only update if it's the first load or a new hour has passed
-                    if (isFirstLoad || (currentHour !== lastHourUpdated && new Date().getMinutes() >= 3)) {
-                        lastHourUpdated = currentHour;
-
-                        if (response.hour_values_data && response.hour_values_data.length > 0) {
-                            renderDashboard(
-                                response.hour_values_data[0],
-                                'last-hour-values-dashboard',
-                                response.columns_values,
-                                response.columns_units,
-                                response.columns_bg
-                            );
-                        }
-
-                        if (response.plots) {
-                            updateLast24HoursPlots(response.plots);
-                        }
-                    }
+                if (response.min_values_data && response.min_values_data.length > 0) {
+                    renderDashboard(
+                        response.min_values_data[0],
+                        response.columns_values,
+                        response.columns_units,
+                        response.columns_bg
+                    );
                 }
             },
             error: function (err) {
-                if (isFirstLoad && updateType === 'hourly') {
-                    $('#loading-message-24').hide();
-                    //$('#loading-message-hour').hide();
-                }
                 console.error("Error in fetchMomentData:", err);
-            },
-            complete: function () {
-                // Mark first load as complete
-                if (isFirstLoad && updateType === 'hourly') {
-                    isFirstLoad = false;
-                    $('#loading-message-24').hide();
-                    //$('#loading-message-hour').hide();
-                }
             }
         });
     }
 
-    function fetchAllDataOnLoad() {
-        // Fetch last-minute data first
-        fetchMomentData('last_minute');
-
-        // Fetch hourly data after a delay to ensure sequential fetching
-        setTimeout(() => {
-            fetchMomentData('hourly');
-        }, 2000); // Adjust delay as needed
-    }
-
-    // Schedule hourly updates
-    function scheduleHourlyUpdates() {
-        // Fetch hourly data on page load
-        fetchMomentData('hourly');
-
-        // Calculate time until 3 minutes after the next hour
-        const now = new Date();
-        const timeUntilNextHour = (60 - now.getMinutes()) * 60000 - now.getSeconds() * 1000;
-
-        setTimeout(() => {
-            fetchMomentData('hourly'); // Fetch once 3 minutes after the next hour
-            setInterval(() => fetchMomentData('hourly'), 3600000); // Fetch hourly data every hour
-        }, timeUntilNextHour + 3 * 60000); // Start 3 minutes after the next hour
-    }
-
-    // Initial fetch and interval start
-    fetchAllDataOnLoad();
-    startFetchInterval();
-    scheduleHourlyUpdates();
-
+    fetchMomentData();
+    setInterval(fetchMomentData, 60000);
 });
+

--- a/templates/index.html
+++ b/templates/index.html
@@ -33,26 +33,7 @@
   <div id="moment-data-container"  class="container">
     <div id="last-min-values-plot" class="dashboard-card">
       <h2>Данни за последната минута</h2>
-      <div id="last-min-values-dashboard" class="dashboard-grid"></div>
-    </div>
-
-    <div id="last-hour-values-plot" class="dashboard-card">
-      <h2>Данни за последния час</h2>
-      <h3>Данните с часа на записа са измерени и осреднени за 60-те минути преди настъпването му</h3>
-      <div id="loading-message-hour" class="loading-container">
-        <div class="loading-spinner"></div>
-        <p>Събиране на данни. Моля изчакайте.</p>
-      </div>
-      <div id="last-hour-values-dashboard" class="dashboard-grid"></div>
-    </div>
-
-    <!-- Last 24 Hours Data Container -->
-    <div id="last-24-hours-plot" class="dashboard-card full-width">
-      <h2>Данни за последните 24 часа</h2>
-      <div id="loading-message-24" class="loading-container">
-        <div class="loading-spinner"></div>
-        <p>Събиране на данни. Моля изчакайте.</p>
-      </div>
+      <div id="last-min-values-dashboard"></div>
     </div>
   </div>
 


### PR DESCRIPTION
## Summary
- remove hourly and 24h plots from moment data
- group last-minute readings into logical sections on dashboard
- clean backend to fetch and serve only last-minute data

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a7616960f0832881249a55d7784e49