### PR TITLE
fix: adjust graph layout to avoid flattening

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -164,6 +164,7 @@ body {
     display: flex;
     flex-direction: column;
     align-items: center;
+    min-height: 400px;
 }
 
 /* Container for the label */

--- a/static/js/graphs.js
+++ b/static/js/graphs.js
@@ -1,24 +1,30 @@
 $(document).ready(function() {
   function renderGraphs() {
     const x = [1,2,3,4,5];
+    const layout = {
+      margin: { t: 30 },
+      height: 400
+    };
+    const config = { responsive: true };
+
     Plotly.newPlot('graph-temp-hum', [
       {x: x, y: [10,12,14,13,11], name: 'T_AIR', type: 'scatter'},
       {x: x, y: [60,58,65,62,61], name: 'REL_HUM', type: 'scatter'}
-    ]);
+    ], layout, config);
     Plotly.newPlot('graph-pressure', [
       {x: x, y: [950,952,951,953,954], name: 'P_ABS', type: 'scatter'},
       {x: x, y: [930,932,931,933,934], name: 'P_REL', type: 'scatter'}
-    ]);
+    ], layout, config);
     Plotly.newPlot('graph-wind', [
       {x: x, y: [5,7,6,8,5], name: 'WIND_SPEED_1', type: 'scatter'},
       {x: x, y: [3,4,5,4,3], name: 'WIND_SPEED_2', type: 'scatter'}
-    ]);
+    ], layout, config);
     Plotly.newPlot('graph-rain', [
       {x: x, y: [0,1,0,2,0], name: 'RAIN_MINUTE', type: 'bar'}
-    ]);
+    ], layout, config);
     Plotly.newPlot('graph-radiation', [
       {x: x, y: [100,200,150,250,300], name: 'RADIATION', type: 'scatter'}
-    ]);
+    ], layout, config);
   }
   $('#period-select').change(renderGraphs);
   renderGraphs();


### PR DESCRIPTION
## Summary
- ensure graph containers have minimum height
- use Plotly layout and responsive config for consistent scaling

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a77a11ebe08328a9ce968ece956801