### PR TITLE
feat: add graph data endpoint

### DIFF
--- a/app.py
+++ b/app.py
@@ -235,6 +235,67 @@ def graphs_page():
     return render_template('graphs.html')
 
 
+@app.route('/graph_data', methods=['GET'])
+@login_required
+def graph_data():
+    period = request.args.get('period', '24h')
+    try:
+        db_connection = get_db_connection()
+        cursor = db_connection.cursor()
+        end_time = datetime.now()
+
+        if period == '24h':
+            start_time = end_time - timedelta(hours=24)
+            table = DB_TABLE_MIN
+        elif period == '30d':
+            start_time = end_time - timedelta(days=30)
+            table = DB_TABLE
+        else:
+            start_time = end_time - timedelta(days=365)
+            table = DB_TABLE
+
+        query = (
+            f"SELECT {DATE_COLUMN}, {', '.join(RAW_DATA_COLUMNS)} FROM {table} "
+            f"WHERE {DATE_COLUMN} >= %s AND {DATE_COLUMN} <= %s ORDER BY {DATE_COLUMN} ASC"
+        )
+        cursor.execute(
+            query,
+            (
+                start_time.strftime('%Y-%m-%d %H:%M:%S'),
+                end_time.strftime('%Y-%m-%d %H:%M:%S'),
+            ),
+        )
+        data = cursor.fetchall()
+        cursor.close()
+        db_connection.close()
+
+        df = pd.DataFrame(data, columns=[DATE_COLUMN] + RAW_DATA_COLUMNS)
+        if df.empty:
+            return jsonify({})
+
+        df[DATE_COLUMN] = pd.to_datetime(df[DATE_COLUMN])
+        df.set_index(DATE_COLUMN, inplace=True)
+
+        if period == '24h':
+            df_others = df.drop(columns=['RADIATION']).resample('10T').mean()
+            rad = df['RADIATION'].resample('H').mean()
+            df_res = df_others.join(rad)
+        else:
+            df_others = df.drop(columns=['RADIATION']).resample('D').mean()
+            rad = df['RADIATION'].resample('D').sum() / 1000
+            df_res = df_others.join(rad.rename('RADIATION'))
+
+        df_res = df_res.dropna(how='all')
+        df_res.reset_index(inplace=True)
+
+        result = {col: df_res[col].tolist() for col in df_res.columns}
+        result[DATE_COLUMN] = [ts.isoformat() for ts in result[DATE_COLUMN]]
+        return jsonify(result)
+    except Exception as e:
+        logger.error(f"Error in /graph_data endpoint: {e}", exc_info=True)
+        return jsonify({'error': str(e)}), 500
+
+
 @app.route('/statistics')
 @login_required
 def statistics_page():

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -164,6 +164,7 @@ body {
     display: flex;
     flex-direction: column;
     align-items: center;
+    min-height: 400px;
 }
 
 /* Container for the label */

--- a/static/js/graphs.js
+++ b/static/js/graphs.js
@@ -1,24 +1,43 @@
 $(document).ready(function() {
   function renderGraphs() {
-    const x = [1,2,3,4,5];
-    Plotly.newPlot('graph-temp-hum', [
-      {x: x, y: [10,12,14,13,11], name: 'T_AIR', type: 'scatter'},
-      {x: x, y: [60,58,65,62,61], name: 'REL_HUM', type: 'scatter'}
-    ]);
-    Plotly.newPlot('graph-pressure', [
-      {x: x, y: [950,952,951,953,954], name: 'P_ABS', type: 'scatter'},
-      {x: x, y: [930,932,931,933,934], name: 'P_REL', type: 'scatter'}
-    ]);
-    Plotly.newPlot('graph-wind', [
-      {x: x, y: [5,7,6,8,5], name: 'WIND_SPEED_1', type: 'scatter'},
-      {x: x, y: [3,4,5,4,3], name: 'WIND_SPEED_2', type: 'scatter'}
-    ]);
-    Plotly.newPlot('graph-rain', [
-      {x: x, y: [0,1,0,2,0], name: 'RAIN_MINUTE', type: 'bar'}
-    ]);
-    Plotly.newPlot('graph-radiation', [
-      {x: x, y: [100,200,150,250,300], name: 'RADIATION', type: 'scatter'}
-    ]);
+    const period = $('#period-select').val();
+    $.getJSON(`/graph_data?period=${period}`, function(data) {
+      const x = data.DateRef.map(d => new Date(d));
+      const tickSettings = {
+        '24h': {dtick: 3600000, tickformat: '%H:%M'},
+        '30d': {dtick: 86400000, tickformat: '%d.%m'},
+        '365d': {dtick: 'M1', tickformat: '%b'}
+      };
+      const baseLayout = {
+        margin: { t: 30 },
+        height: 400,
+        xaxis: tickSettings[period]
+      };
+      const config = { responsive: true };
+
+      Plotly.newPlot('graph-temp-hum', [
+        {x: x, y: data.T_AIR, name: 'T_AIR', type: 'scatter'},
+        {x: x, y: data.REL_HUM, name: 'REL_HUM', type: 'scatter'}
+      ], {...baseLayout, title: 'Температура и Влажност'}, config);
+
+      Plotly.newPlot('graph-pressure', [
+        {x: x, y: data.P_ABS, name: 'P_ABS', type: 'scatter'},
+        {x: x, y: data.P_REL, name: 'P_REL', type: 'scatter'}
+      ], {...baseLayout, title: 'Налягане'}, config);
+
+      Plotly.newPlot('graph-wind', [
+        {x: x, y: data.WIND_SPEED_1, name: 'WIND_SPEED_1', type: 'scatter'},
+        {x: x, y: data.WIND_SPEED_2, name: 'WIND_SPEED_2', type: 'scatter'}
+      ], {...baseLayout, title: 'Вятър'}, config);
+
+      Plotly.newPlot('graph-rain', [
+        {x: x, y: data.RAIN_MINUTE, name: 'RAIN_MINUTE', type: 'bar'}
+      ], {...baseLayout, title: 'Дъжд'}, config);
+
+      Plotly.newPlot('graph-radiation', [
+        {x: x, y: data.RADIATION, name: 'RADIATION', type: 'scatter'}
+      ], {...baseLayout, title: 'Радиация'}, config);
+    });
   }
   $('#period-select').change(renderGraphs);
   renderGraphs();


### PR DESCRIPTION
## Summary
- serve aggregated datasets for 24h, 30d and 365d ranges via new `/graph_data` API
- render graphs with titles and period-specific axis formatting using fetched data

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a77a11ebe08328a9ce968ece956801