### PR TITLE
Add month/year selectable report table

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -492,3 +492,46 @@ body {
     0% { transform: rotate(0deg); }
     100% { transform: rotate(360deg); }
 }
+
+/* Report table styling */
+#report-container {
+  overflow-x: auto;
+}
+
+#report-table {
+  border-collapse: collapse;
+  width: 100%;
+  min-width: 1200px;
+}
+
+#report-table th,
+#report-table td {
+  border: 1px solid #ccc;
+  padding: 4px;
+  min-width: 80px;
+  text-align: center;
+}
+
+#report-table .sticky-col {
+  position: sticky;
+  left: 0;
+  background: #fff;
+  z-index: 2;
+}
+
+#report-table thead th {
+  position: sticky;
+  top: 0;
+  background: #f0f0f0;
+  z-index: 3;
+}
+
+.report-controls {
+  margin-bottom: 10px;
+}
+
+.report-controls select,
+.report-controls button {
+  margin-left: 5px;
+  margin-right: 5px;
+}

--- a/static/js/report.js
+++ b/static/js/report.js
@@ -1,23 +1,55 @@
 $(document).ready(function() {
-  function buildTable() {
-    const days = Array.from({length: 31}, (_, i) => i + 1);
-    const params = [
-      {name:'Температура °C'},
-      {name:'Относителна влажност %'},
-      {name:'Относително налягане hPa'},
-      {name:'Скорост на вятъра km/h'},
-      {name:'Скорост на вятъра m/s'},
-      {name:'Посока на вятъра (DEG)'},
-      {name:'Валежи (l/m2)'},
-      {name:'Температура 14:00 °C'},
-      {name:'Отн. влажност 14:00 %'},
-      {name:'Отн. налягане 14:00 hPa'},
-      {name:'Изпарение mm/d'}
-    ];
-    let thead = '<tr><th>Параметър</th>' + days.map(d=>`<th>${d}</th>`).join('') + '</tr>';
+  const params = [
+    { key: 'T_AIR', name: 'Температура °C' },
+    { key: 'REL_HUM', name: 'Относителна влажност %' },
+    { key: 'P_REL', name: 'Относително налягане hPa' },
+    { key: 'WIND_SPEED_1', name: 'Скорост на вятъра km/h' },
+    { key: 'WIND_SPEED_2', name: 'Скорост на вятъра m/s' },
+    { key: 'WIND_DIR', name: 'Посока на вятъра (DEG)' },
+    { key: 'RAIN', name: 'Валежи (l/m2)' },
+    { key: 'T_AIR_14', name: 'Температура 14:00 °C' },
+    { key: 'REL_HUM_14', name: 'Отн. влажност 14:00 %' },
+    { key: 'P_REL_14', name: 'Отн. налягане 14:00 hPa' },
+    { key: 'EVAPOR_DAY', name: 'Изпарение mm/d' }
+  ];
+  const days = Array.from({length: 31}, (_, i) => i + 1);
+
+  function buildTable(data) {
+    let thead = '<tr><th class="sticky-col">Параметър</th>' +
+      days.map(d => `<th>${d}</th>`).join('') + '</tr>';
     $('#report-table thead').html(thead);
-    let rows = params.map(p => '<tr><td>'+p.name+'</td>' + days.map(()=>'<td></td>').join('') + '</tr>').join('');
+    let rows = params.map(p => {
+      const values = data[p.key] || [];
+      const cells = days.map(d => {
+        const v = values[d-1];
+        return `<td>${v !== undefined && v !== null ? v : ''}</td>`;
+      }).join('');
+      return `<tr><td class="sticky-col">${p.name}</td>${cells}</tr>`;
+    }).join('');
     $('#report-table tbody').html(rows);
   }
-  buildTable();
+
+  function loadData(year, month) {
+    $.getJSON(`/report_data?year=${year}&month=${month}`, function(data) {
+      buildTable(data);
+    });
+  }
+
+  const monthSelect = $('#month-select');
+  for (let m = 1; m <= 12; m++) {
+    monthSelect.append(`<option value="${m}">${m}</option>`);
+  }
+  const yearSelect = $('#year-select');
+  const currentYear = new Date().getFullYear();
+  for (let y = currentYear - 5; y <= currentYear; y++) {
+    yearSelect.append(`<option value="${y}">${y}</option>`);
+  }
+  monthSelect.val(new Date().getMonth() + 1);
+  yearSelect.val(currentYear);
+
+  $('#load-report').on('click', function() {
+    loadData(yearSelect.val(), monthSelect.val());
+  });
+
+  loadData(currentYear, new Date().getMonth() + 1);
 });

--- a/templates/report.html
+++ b/templates/report.html
@@ -22,11 +22,20 @@
       </a>
     </div>
   </div>
-  <div class="container" id="report-container">
-    <table id="report-table" class="dashboard-card">
-      <thead></thead>
-      <tbody></tbody>
-    </table>
+  <div class="container">
+    <div class="report-controls">
+      <label for="month-select">Месец:</label>
+      <select id="month-select"></select>
+      <label for="year-select">Година:</label>
+      <select id="year-select"></select>
+      <button id="load-report">Покажи</button>
+    </div>
+    <div id="report-container">
+      <table id="report-table">
+        <thead></thead>
+        <tbody></tbody>
+      </table>
+    </div>
   </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- fetch daily statistics for a selected month and year via new `/report_data` endpoint
- render report table with sticky first column, grid lines and horizontal scrolling
- allow month/year selection on the report page

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a79924d9ec8328af86997fb0e940cc