### PR TITLE
Add month/year selectable report table and show site title on all pages

### DIFF
--- a/app.py
+++ b/app.py
@@ -507,6 +507,93 @@ def report_page():
     return render_template('report.html')
 
 
+@app.route('/report_data', methods=['GET'])
+@login_required
+def report_data_endpoint():
+    """Return daily statistics for a given month and year."""
+    year = request.args.get('year', type=int)
+    month = request.args.get('month', type=int)
+    if not year or not month:
+        return jsonify({})
+    try:
+        db_connection = get_db_connection()
+        cursor = db_connection.cursor()
+        query = (
+            f"SELECT {DATE_COLUMN}, T_AIR, REL_HUM, P_REL, WIND_SPEED_1, WIND_SPEED_2, "
+            f"WIND_DIR, RAIN_MINUTE, EVAPOR_MINUTE FROM {DB_TABLE} "
+            f"WHERE YEAR({DATE_COLUMN}) = %s AND MONTH({DATE_COLUMN}) = %s "
+            f"ORDER BY {DATE_COLUMN} ASC"
+        )
+        cursor.execute(query, (year, month))
+        data = cursor.fetchall()
+        cursor.close()
+        db_connection.close()
+
+        df = pd.DataFrame(
+            data,
+            columns=[
+                DATE_COLUMN,
+                "T_AIR",
+                "REL_HUM",
+                "P_REL",
+                "WIND_SPEED_1",
+                "WIND_SPEED_2",
+                "WIND_DIR",
+                "RAIN_MINUTE",
+                "EVAPOR_MINUTE",
+            ],
+        )
+        if df.empty:
+            return jsonify({})
+
+        df[DATE_COLUMN] = pd.to_datetime(df[DATE_COLUMN])
+        df.set_index(DATE_COLUMN, inplace=True)
+
+        import calendar
+
+        days_in_month = calendar.monthrange(year, month)[1]
+        idx = pd.date_range(
+            start=datetime(year, month, 1), periods=days_in_month, freq="D"
+        )
+
+        daily_mean = df[
+            [
+                "T_AIR",
+                "REL_HUM",
+                "P_REL",
+                "WIND_SPEED_1",
+                "WIND_SPEED_2",
+                "WIND_DIR",
+            ]
+        ].resample("D").mean()
+        daily_rain = df["RAIN_MINUTE"].resample("D").sum().rename("RAIN")
+        daily_evapor = (
+            df["EVAPOR_MINUTE"].resample("D").sum().rename("EVAPOR_DAY")
+        )
+        at_14 = (
+            df.between_time("14:00", "14:00")[
+                ["T_AIR", "REL_HUM", "P_REL"]
+            ].resample("D").mean().add_suffix("_14")
+        )
+
+        combined = (
+            pd.DataFrame(index=idx)
+            .join(daily_mean)
+            .join(daily_rain)
+            .join(at_14)
+            .join(daily_evapor)
+        )
+        combined = combined.round(1)
+        # Replace NaN values with None so JSON is valid
+        combined = combined.where(pd.notnull(combined), None)
+
+        result = {col: combined[col].tolist() for col in combined.columns}
+        return jsonify(result)
+    except Exception as e:
+        logger.error(f"Error in /report_data endpoint: {e}", exc_info=True)
+        return jsonify({"error": str(e)}), 500
+
+
 @app.route('/plot', methods=['POST'])
 def plot():
     global my_df

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -492,3 +492,46 @@ body {
     0% { transform: rotate(0deg); }
     100% { transform: rotate(360deg); }
 }
+
+/* Report table styling */
+#report-container {
+  overflow-x: auto;
+}
+
+#report-table {
+  border-collapse: collapse;
+  width: 100%;
+  min-width: 1200px;
+}
+
+#report-table th,
+#report-table td {
+  border: 1px solid #ccc;
+  padding: 4px;
+  min-width: 80px;
+  text-align: center;
+}
+
+#report-table .sticky-col {
+  position: sticky;
+  left: 0;
+  background: #fff;
+  z-index: 2;
+}
+
+#report-table thead th {
+  position: sticky;
+  top: 0;
+  background: #f0f0f0;
+  z-index: 3;
+}
+
+.report-controls {
+  margin-bottom: 10px;
+}
+
+.report-controls select,
+.report-controls button {
+  margin-left: 5px;
+  margin-right: 5px;
+}

--- a/static/js/report.js
+++ b/static/js/report.js
@@ -1,23 +1,86 @@
 $(document).ready(function() {
-  function buildTable() {
-    const days = Array.from({length: 31}, (_, i) => i + 1);
-    const params = [
-      {name:'Температура °C'},
-      {name:'Относителна влажност %'},
-      {name:'Относително налягане hPa'},
-      {name:'Скорост на вятъра km/h'},
-      {name:'Скорост на вятъра m/s'},
-      {name:'Посока на вятъра (DEG)'},
-      {name:'Валежи (l/m2)'},
-      {name:'Температура 14:00 °C'},
-      {name:'Отн. влажност 14:00 %'},
-      {name:'Отн. налягане 14:00 hPa'},
-      {name:'Изпарение mm/d'}
-    ];
-    let thead = '<tr><th>Параметър</th>' + days.map(d=>`<th>${d}</th>`).join('') + '</tr>';
+  const params = [
+    { key: 'T_AIR', name: 'Температура °C' },
+    { key: 'REL_HUM', name: 'Относителна влажност %' },
+    { key: 'P_REL', name: 'Относително налягане hPa' },
+    { key: 'WIND_SPEED_1', name: 'Скорост на вятъра km/h' },
+    { key: 'WIND_SPEED_2', name: 'Скорост на вятъра m/s' },
+    { key: 'WIND_DIR', name: 'Посока на вятъра (DEG)' },
+    { key: 'RAIN', name: 'Валежи (l/m2)' },
+    { key: 'T_AIR_14', name: 'Температура 14:00 °C' },
+    { key: 'REL_HUM_14', name: 'Отн. влажност 14:00 %' },
+    { key: 'P_REL_14', name: 'Отн. налягане 14:00 hPa' },
+    { key: 'EVAPOR_DAY', name: 'Изпарение mm/d' }
+  ];
+  const days = Array.from({length: 31}, (_, i) => i + 1);
+  let currentData = {};
+
+  function buildTable(data) {
+    let thead = '<tr><th class="sticky-col">Параметър</th>' +
+      days.map(d => `<th>${d}</th>`).join('') + '</tr>';
     $('#report-table thead').html(thead);
-    let rows = params.map(p => '<tr><td>'+p.name+'</td>' + days.map(()=>'<td></td>').join('') + '</tr>').join('');
+    let rows = params.map(p => {
+      const values = data[p.key] || [];
+      const cells = days.map(d => {
+        const v = values[d-1];
+        return `<td>${v !== undefined && v !== null ? Number(v).toFixed(1) : ''}</td>`;
+      }).join('');
+      return `<tr><td class="sticky-col">${p.name}</td>${cells}</tr>`;
+    }).join('');
     $('#report-table tbody').html(rows);
   }
-  buildTable();
+
+  function loadData(year, month) {
+    $.getJSON(`/report_data?year=${year}&month=${month}`)
+      .done(function(data) {
+        currentData = data;
+        buildTable(data);
+      })
+      .fail(function() {
+        console.error('Failed to load report data');
+        buildTable({});
+      });
+  }
+
+  const monthSelect = $('#month-select');
+  for (let m = 1; m <= 12; m++) {
+    monthSelect.append(`<option value="${m}">${m}</option>`);
+  }
+  const yearSelect = $('#year-select');
+  const currentYear = new Date().getFullYear();
+  for (let y = currentYear - 5; y <= currentYear; y++) {
+    yearSelect.append(`<option value="${y}">${y}</option>`);
+  }
+  monthSelect.val(new Date().getMonth() + 1);
+  yearSelect.val(currentYear);
+
+  $('#load-report').on('click', function() {
+    loadData(yearSelect.val(), monthSelect.val());
+  });
+
+  $('#export-csv').on('click', function() {
+    const year = yearSelect.val();
+    const month = String(monthSelect.val()).padStart(2, '0');
+    let csv = ['Параметър,' + days.join(',')];
+    params.forEach(p => {
+      const values = currentData[p.key] || [];
+      const row = [p.name];
+      for (let i = 0; i < days.length; i++) {
+        const v = values[i];
+        row.push(v !== undefined && v !== null ? Number(v).toFixed(1) : '');
+      }
+      csv.push(row.join(','));
+    });
+    const csvContent = csv.join('\n');
+    const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
+    const link = document.createElement('a');
+    link.href = URL.createObjectURL(blob);
+    link.download = `Meteo_Dushanci_${month}_${year}.csv`;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(link.href);
+  });
+
+  loadData(currentYear, new Date().getMonth() + 1);
 });

--- a/templates/graphs.html
+++ b/templates/graphs.html
@@ -17,6 +17,7 @@
       <a href="/statistics">Статистика</a>
       <a href="/report">Справка</a>
     </nav>
+    <h1>Система за следене на метеорологичните условия на яз. Душанци</h1>
     <div class="logout-btn-container">
       <a href="{{ url_for('logout') }}">
         <button class="logout-btn">Logout</button>

--- a/templates/login.html
+++ b/templates/login.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Login - Мобилна станция РИОСВ</title>
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/styles.css') }}">
   <style>
     body {
       font-family: Arial, sans-serif;
@@ -11,9 +12,17 @@
       padding: 0;
       background-color: #f5f5f5;
       display: flex;
+      flex-direction: column;
+      min-height: 100vh;
+      align-items: center;
+    }
+
+    .login-wrapper {
+      flex: 1;
+      display: flex;
       justify-content: center;
       align-items: center;
-      height: 100vh;
+      width: 100%;
     }
 
     .login-container {
@@ -74,9 +83,13 @@
   </style>
 </head>
 <body>
-  <div class="login-container">
-    <h1>Вход</h1>
-    <form action="/login" method="POST">
+  <div class="banner">
+    <h1>Система за следене на метеорологичните условия на яз. Душанци</h1>
+  </div>
+  <div class="login-wrapper">
+    <div class="login-container">
+      <h1>Вход</h1>
+      <form action="/login" method="POST">
       <!-- Display error messages if any -->
       <div class="error-message">{{ error_message }}</div>
       <div class="info-message">{{ info_message }}</div>
@@ -89,6 +102,7 @@
 
       <button type="submit">Влез</button>
     </form>
+    </div>
   </div>
 </body>
 </html>

--- a/templates/report.html
+++ b/templates/report.html
@@ -16,17 +16,28 @@
       <a href="/statistics">Статистика</a>
       <a href="/report">Справка</a>
     </nav>
+    <h1>Система за следене на метеорологичните условия на яз. Душанци</h1>
     <div class="logout-btn-container">
       <a href="{{ url_for('logout') }}">
         <button class="logout-btn">Logout</button>
       </a>
     </div>
   </div>
-  <div class="container" id="report-container">
-    <table id="report-table" class="dashboard-card">
-      <thead></thead>
-      <tbody></tbody>
-    </table>
+  <div class="container">
+    <div class="report-controls">
+      <label for="month-select">Месец:</label>
+      <select id="month-select"></select>
+      <label for="year-select">Година:</label>
+      <select id="year-select"></select>
+      <button id="load-report">Покажи</button>
+      <button id="export-csv">Експорт CSV</button>
+    </div>
+    <div id="report-container">
+      <table id="report-table">
+        <thead></thead>
+        <tbody></tbody>
+      </table>
+    </div>
   </div>
 </body>
 </html>

--- a/templates/statistics.html
+++ b/templates/statistics.html
@@ -16,6 +16,7 @@
       <a href="/statistics">Статистика</a>
       <a href="/report">Справка</a>
     </nav>
+    <h1>Система за следене на метеорологичните условия на яз. Душанци</h1>
     <div class="logout-btn-container">
       <a href="{{ url_for('logout') }}">
         <button class="logout-btn">Logout</button>


### PR DESCRIPTION
## Summary
- fetch daily statistics for a selected month and year via new `/report_data` endpoint
- render report table with sticky first column, grid lines and horizontal scrolling
- allow month/year selection on the report page
- ensure report API returns JSON with nulls instead of NaN to populate table
- handle client-side errors when loading report data
- round displayed values to one decimal place and enable CSV export with filename `Meteo_Dushanci_mm_yyyy`
- display "Система за следене на метеорологичните условия на яз. Душанци" across graphs, statistics, report and login pages

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a79924d9ec8328af86997fb0e940cc