### PR TITLE
Allow full-width layouts for dashboard plots

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -65,7 +65,6 @@ body {
 .container {
   padding: 20px;
   text-align: center;
-  max-width: 100%;
 }
 
 * {
@@ -79,7 +78,6 @@ body {
   justify-content: space-around; /* Align items uniformly */
   margin: 0 auto; /* Center the entire dashboard */
   text-align: center;
-  max-width: 100%; /* Ensure the container doesn’t exceed parent width */
   box-sizing: border-box; /* Prevent elements from going out of bounds */
 }
 
@@ -157,7 +155,6 @@ body {
   margin: 10px auto;
   padding: 20px;
   width: 95%;
-  max-width: 650px;
 }
 
 .dashboard-card.full-width {
@@ -186,8 +183,15 @@ body {
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
   margin: 20px auto;
   width: 85%;
-  max-width: 600px;
   font-size: 16px;
+}
+
+#statistics-container .dashboard-card {
+  max-width: 650px;
+}
+
+#statistics-container .controls {
+  max-width: 600px;
 }
 
 .controls p {


### PR DESCRIPTION
## Summary
- Remove global `max-width` constraints from container and card styles
- Limit `max-width` only to statistics-specific cards and controls

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a814765c4c8328a2349848d0fe251b