### PR TITLE
Show full Plotly charts within dashboard cards

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -156,16 +156,38 @@ body {
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
   margin: 10px auto;
   padding: 20px;
-  width: 95%;
-  max-width: 650px;
+  width: 100%;
 }
 
 .dashboard-card.full-width {
-    width: 97%;
+    width: 100%;
     min-height: 400px;
     height: 400px;
     margin: 20px auto;
     display: block;
+}
+
+/* Ensure Plotly charts stay within their cards without clipping */
+.dashboard-card .plot-container {
+    width: 100% !important;
+    margin: 0 auto;
+    display: flex;
+    justify-content: center;
+}
+
+/* Allow Plotly's internal SVG to size naturally */
+.dashboard-card .main-svg {
+    max-width: 90%;
+    width: 90% !important;
+    height: auto !important;
+    margin: 0 auto;
+}
+
+/* Statistics section retains width constraints */
+#statistics-container .dashboard-card,
+#statistics-container .controls {
+    width: 95%;
+    max-width: 650px;
 }
 
 /* Container for the label */
@@ -185,11 +207,8 @@ body {
   border-radius: 10px;
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
   margin: 20px auto;
-  width: 85%;
-  max-width: 600px;
   font-size: 16px;
 }
-
 .controls p {
   font-weight: bold;
   margin-bottom: 20px;


### PR DESCRIPTION
## Summary
- Expand dashboard cards and Plotly containers to full width so charts are not clipped
- Restrict card and control widths only under the statistics section
- Shrink Plotly charts inside dashboard cards to prevent overflow

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a814765c4c8328a2349848d0fe251b