### PR TITLE
Refine layouts and export formatting

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -86,7 +86,7 @@ body {
 
 /* Group container for last minute data */
 .dashboard-group {
-  margin-bottom: 20px;
+  margin-bottom: 10px;
 }
 
 
@@ -105,7 +105,7 @@ body {
 .dashboard-grid {
   display: grid;
   grid-template-columns: repeat(4, 1fr); /* Four equal columns */
-  gap: 20px; /* More space between items */
+  gap: 10px; /* Reduced space between items */
   padding: 10px; /* Consistent padding inside the grid */
   box-sizing: border-box; /* Ensure padding is accounted for */
 }
@@ -118,7 +118,7 @@ body {
 
 /* Ensure all dashboard items fit within the grid */
 .dashboard-item {
-  padding: 15px;
+  padding: 10px;
   border-radius: 8px;
   display: flex;
   flex-direction: column;
@@ -147,7 +147,7 @@ body {
 }
 
 .dashboard-item .variable-value {
-  font-size: 1.2em;
+  font-size: 1.1em;
   color: #333;
 }
 .dashboard-card {
@@ -156,7 +156,7 @@ body {
   border-radius: 8px;
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
   margin: 10px auto;
-  padding: 20px;
+  padding: 15px;
   width: 100%;
 }
 
@@ -252,8 +252,8 @@ body {
 .stats-item {
   display: flex;
   justify-content: space-between;
-  gap: 8px;
-  padding: 4px 8px;
+  gap: 4px;
+  padding: 2px 4px;
   border-bottom: 1px solid #e0e0e0;
   width: 50%;
 }
@@ -550,8 +550,8 @@ body {
 
 #report-table {
   border-collapse: collapse;
-  width: 100%;
-  min-width: 900px;
+  width: auto;
+  min-width: 0;
   font-size: 12px;
   background: #fff;
 }
@@ -559,8 +559,8 @@ body {
 #report-table th,
 #report-table td {
   border: 1px solid #ccc;
-  padding: 4px;
-  min-width: 60px;
+  padding: 2px;
+  min-width: 40px;
   text-align: center;
 }
 

--- a/static/js/graphs.js
+++ b/static/js/graphs.js
@@ -41,7 +41,7 @@ $(document).ready(function() {
               type: 'scatter',
               yaxis: 'y1',
               line: { shape: 'spline' },
-              hovertemplate: '%{name}: %{y:.1f}<extra></extra>'
+              hovertemplate: '%{fullData.name}: %{y:.1f}<extra></extra>'
             },
             {
               x,
@@ -50,7 +50,7 @@ $(document).ready(function() {
               type: 'scatter',
               yaxis: 'y2',
               line: { shape: 'spline' },
-              hovertemplate: '%{name}: %{y:.1f}<extra></extra>'
+              hovertemplate: '%{fullData.name}: %{y:.1f}<extra></extra>'
             }
           ],
           layout: {
@@ -77,7 +77,7 @@ $(document).ready(function() {
               type: 'scatter',
               yaxis: 'y1',
               line: { shape: 'spline' },
-              hovertemplate: '%{name}: %{y:.1f}<extra></extra>'
+              hovertemplate: '%{fullData.name}: %{y:.1f}<extra></extra>'
             },
             {
               x,
@@ -86,7 +86,7 @@ $(document).ready(function() {
               type: 'scatter',
               yaxis: 'y2',
               line: { shape: 'spline' },
-              hovertemplate: '%{name}: %{y:.1f}<extra></extra>'
+              hovertemplate: '%{fullData.name}: %{y:.1f}<extra></extra>'
             }
           ],
           layout: {
@@ -113,7 +113,7 @@ $(document).ready(function() {
               type: 'scatter',
               yaxis: 'y1',
               line: { shape: 'spline' },
-              hovertemplate: '%{name}: %{y:.1f}<extra></extra>'
+              hovertemplate: '%{fullData.name}: %{y:.1f}<extra></extra>'
             },
             {
               x,
@@ -122,7 +122,7 @@ $(document).ready(function() {
               type: 'scatter',
               yaxis: 'y2',
               line: { shape: 'spline' },
-              hovertemplate: '%{name}: %{y:.1f}<extra></extra>'
+              hovertemplate: '%{fullData.name}: %{y:.1f}<extra></extra>'
             }
           ],
           layout: {
@@ -148,7 +148,7 @@ $(document).ready(function() {
               name: 'Дъжд',
               type: 'bar',
               marker: { color: 'blue' },
-              hovertemplate: '%{name}: %{y:.1f}<extra></extra>'
+              hovertemplate: '%{fullData.name}: %{y:.1f}<extra></extra>'
             }
           ],
           layout: {
@@ -165,7 +165,7 @@ $(document).ready(function() {
               name: 'Изпарение',
               type: 'bar',
               marker: { color: 'green' },
-              hovertemplate: '%{name}: %{y:.1f}<extra></extra>'
+              hovertemplate: '%{fullData.name}: %{y:.1f}<extra></extra>'
             }
           ],
           layout: {
@@ -182,7 +182,7 @@ $(document).ready(function() {
               name: 'Слънчева радиация',
               type: 'bar',
               marker: { color: 'orange' },
-              hovertemplate: '%{name}: %{y:.1f}<extra></extra>'
+              hovertemplate: '%{fullData.name}: %{y:.1f}<extra></extra>'
             }
           ],
           layout: {

--- a/static/js/report.js
+++ b/static/js/report.js
@@ -69,7 +69,7 @@ $(document).ready(function() {
       const row = [p.name];
       for (let i = 0; i < days.length; i++) {
         const v = values[i];
-        row.push(v !== undefined && v !== null ? Number(v).toLocaleString('bg-BG', { minimumFractionDigits: 1, maximumFractionDigits: 1 }) : '');
+        row.push(v !== undefined && v !== null ? Number(v).toLocaleString('en-US', { minimumFractionDigits: 1, maximumFractionDigits: 1, useGrouping: false }) : '');
       }
         csv.push(row.join(';'));
     });


### PR DESCRIPTION
## Summary
- Use dot as the decimal separator when exporting monthly CSV data.
- Tighten spacing in dashboard and statistics views so four panels fit on a screen.
- Show full trace names on graphs and narrow the monthly report table for single-page viewing.

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68b6a777086483289004cb2fb34383d0