### PR TITLE
Switch to PyMySQL for database connections

### DIFF
--- a/insertMissingDataFromCSV.py
+++ b/insertMissingDataFromCSV.py
@@ -72,9 +72,12 @@ def read_config():
     return db_config, ftp_config
 
 
-# Step 2: Connect to the MySQL database using SQLAlchemy
+# Step 2: Connect to the MySQL database using SQLAlchemy and PyMySQL
 def create_db_connection(db_config):
-    conn_str = f"mysql+mysqlconnector://{db_config['username']}:{db_config['password']}@{db_config['host']}:{db_config['port']}/{db_config['database']}"
+    conn_str = (
+        f"mysql+pymysql://{db_config['username']}:{db_config['password']}@"
+        f"{db_config['host']}:{db_config['port']}/{db_config['database']}"
+    )
     engine = sa.create_engine(conn_str, echo=True)
     return engine
 

--- a/mean_1h.py
+++ b/mean_1h.py
@@ -81,8 +81,8 @@ def openSQLconnection(start_date):
     database = config.get('SQL', 'database')
     raw_table = config.get('SQL', 'DB_TABLE_MIN')
 
-    # Connect to the MySQL database using SQLAlchemy
-    conn_str = f'mysql+mysqlconnector://{user}:{password}@{host}:{port}/{database}'
+    # Connect to the MySQL database using SQLAlchemy and PyMySQL
+    conn_str = f'mysql+pymysql://{user}:{password}@{host}:{port}/{database}'
     engine = sa.create_engine(conn_str, echo=True)
 
     # Construct the list of column names for the query

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,3 @@ pymysql
 openpyxl
 SQLAlchemy
 numpy
-mysql-connector-python


### PR DESCRIPTION
## Summary
- Connect to MySQL/MariaDB using SQLAlchemy with the PyMySQL driver.
- Drop mysql-connector dependency from requirements.

## Testing
- `python -m py_compile insertMissingDataFromCSV.py mean_1h.py`


------
https://chatgpt.com/codex/tasks/task_e_68c2a818016483288bb8a3ea0a180205