### PR TITLE
Switch to PyMySQL for database connections

### DIFF
--- a/insertMissingDataFromCSV.py
+++ b/insertMissingDataFromCSV.py
@@ -72,9 +72,12 @@ def read_config():
     return db_config, ftp_config
 
 
-# Step 2: Connect to the MySQL database using SQLAlchemy
+# Step 2: Connect to the MySQL database using SQLAlchemy and PyMySQL
 def create_db_connection(db_config):
-    conn_str = f"mysql+mysqlconnector://{db_config['username']}:{db_config['password']}@{db_config['host']}:{db_config['port']}/{db_config['database']}"
+    conn_str = (
+        f"mysql+pymysql://{db_config['username']}:{db_config['password']}@"
+        f"{db_config['host']}:{db_config['port']}/{db_config['database']}"
+    )
     engine = sa.create_engine(conn_str, echo=True)
     return engine
 

--- a/mean_1h.py
+++ b/mean_1h.py
@@ -6,29 +6,6 @@ import sqlalchemy as sa
 import sys
 import numpy as np
 import configparser
-import os
-import logging
-from logging.handlers import RotatingFileHandler
-
-
-def setup_logger(log_filename):
-    log_formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s')
-
-    if not os.path.exists(log_filename):
-        open(log_filename, 'w').close()
-
-    log_handler = RotatingFileHandler(log_filename, mode='a', maxBytes=10 * 1024 * 1024, backupCount=5)
-    log_handler.setFormatter(log_formatter)
-
-    logger = logging.getLogger(__name__)
-    logger.setLevel(logging.INFO)
-    logger.addHandler(log_handler)
-
-    return logger
-
-
-log_filename = 'mean1H_LOG.log'
-logger = setup_logger(log_filename)
 
 # Load configuration from config.ini
 with open('config.ini', 'r', encoding='utf-8') as config_file:
@@ -81,8 +58,8 @@ def openSQLconnection(start_date):
     database = config.get('SQL', 'database')
     raw_table = config.get('SQL', 'DB_TABLE_MIN')
 
-    # Connect to the MySQL database using SQLAlchemy
-    conn_str = f'mysql+mysqlconnector://{user}:{password}@{host}:{port}/{database}'
+    # Connect to the MySQL database using SQLAlchemy and PyMySQL
+    conn_str = f'mysql+pymysql://{user}:{password}@{host}:{port}/{database}'
     engine = sa.create_engine(conn_str, echo=True)
 
     # Construct the list of column names for the query
@@ -101,9 +78,8 @@ def openSQLconnection(start_date):
         else:
             raw_data['DateRef'] = pd.to_datetime(raw_data['DateRef'])  # Convert DateRef column to datetime type
             return 'Exists_data_for_that_hour'
-        logger.info="SQL raw data is read"
     except Exception as e:
-        logger.info = f"openSQLconnection {e}"
+        print(f"openSQLconnection {e}")
     st=1
 
 
@@ -146,9 +122,8 @@ def makeHourData():
         # output_data.at[0, 'DateRef'] = start_time
         output_data.at[0, 'DateRef'] = start_time + pd.Timedelta(hours=1)
 
-        logger.info = "makeHourData ok"
     except Exception as e:
-        logger.info = f"makeHourData {e}"
+        print(f"makeHourData {e}")
 
 
 def populateMean1hour():

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,3 @@ pymysql
 openpyxl
 SQLAlchemy
 numpy
-mysql-connector-python

--- a/static/js/graphs.js
+++ b/static/js/graphs.js
@@ -226,4 +226,5 @@ $(document).ready(function() {
   }
   $('#period-select').change(renderGraphs);
   renderGraphs();
+  setInterval(renderGraphs, 60000);
 });

--- a/static/js/statistics.js
+++ b/static/js/statistics.js
@@ -21,15 +21,20 @@ $(document).ready(function () {
     );
   }
 
-  fetch('/statistics_data')
-    .then(response => response.json())
-    .then(data => {
-      $('#stats-today').html(listToHtml(data.today || []));
-      $('#stats-month').html(listToHtml(data.month || []));
-      $('#stats-year').html(listToHtml(data.year || []));
-      $('#stats-alltime').html(listToHtml(data.all || []));
-    })
-    .catch(err => {
-      console.error('Error loading statistics', err);
-    });
+  function fetchStatistics() {
+    fetch('/statistics_data')
+      .then(response => response.json())
+      .then(data => {
+        $('#stats-today').html(listToHtml(data.today || []));
+        $('#stats-month').html(listToHtml(data.month || []));
+        $('#stats-year').html(listToHtml(data.year || []));
+        $('#stats-alltime').html(listToHtml(data.all || []));
+      })
+      .catch(err => {
+        console.error('Error loading statistics', err);
+      });
+  }
+
+  fetchStatistics();
+  setInterval(fetchStatistics, 60000);
 });


### PR DESCRIPTION
## Summary
- Connect to MySQL/MariaDB using SQLAlchemy with the PyMySQL driver.
- Drop mysql-connector dependency from requirements.
- Remove mean1H_LOG logger from mean_1h.py.
- Refresh graphs and statistics pages every minute without manual reload.

## Testing
- `python -m py_compile insertMissingDataFromCSV.py mean_1h.py`


------
https://chatgpt.com/codex/tasks/task_e_68c2a818016483288bb8a3ea0a180205