### PR TITLE
Handle decimal comma in reports

### DIFF
--- a/app.py
+++ b/app.py
@@ -659,9 +659,11 @@ def report_data_endpoint():
             )
 
         combined = combined.round(1)
-        combined = combined.astype(object).where(pd.notnull(combined), None)
 
-        result = {col: combined[col].tolist() for col in combined.columns}
+        def format_val(v):
+            return f"{v:.1f}".replace('.', ',') if pd.notnull(v) else None
+
+        result = {col: [format_val(v) for v in combined[col]] for col in combined.columns}
         return jsonify(result)
     except Exception as e:
         logger.error(f"Error in /report_data endpoint: {e}", exc_info=True)
@@ -836,6 +838,11 @@ def export_to_excel():
         # Write data
         for row_idx, (_, row) in enumerate(filtered_df.iterrows(), start=12):
             for col_idx, value in enumerate(row, start=2):
+                if isinstance(value, str):
+                    try:
+                        value = float(value.replace(',', '.'))
+                    except ValueError:
+                        pass
                 ws.cell(row=row_idx, column=col_idx, value=value)
 
         # Save and send file
@@ -893,6 +900,11 @@ def export2_to_excel():
         # Write data
         for row_idx, (_, row) in enumerate(filtered_df.iterrows(), start=12):
             for col_idx, value in enumerate(row, start=2):
+                if isinstance(value, str):
+                    try:
+                        value = float(value.replace(',', '.'))
+                    except ValueError:
+                        pass
                 ws.cell(row=row_idx, column=col_idx, value=value)
 
         # Save and send file

--- a/static/js/report.js
+++ b/static/js/report.js
@@ -29,7 +29,8 @@ $(document).ready(function() {
       const values = data[p.key] || [];
       const cells = days.map(d => {
         const v = values[d-1];
-        return `<td>${v !== undefined && v !== null ? Number(v).toLocaleString('bg-BG', { minimumFractionDigits: 1, maximumFractionDigits: 1 }) : ''}</td>`;
+        const num = typeof v === 'string' ? parseFloat(v.replace(',', '.')) : v;
+        return `<td>${v !== undefined && v !== null && !isNaN(num) ? num.toLocaleString('bg-BG', { minimumFractionDigits: 1, maximumFractionDigits: 1, useGrouping: false }) : ''}</td>`;
       }).join('');
       return `<tr><td class="sticky-col">${p.name}, ${p.unit}</td>${cells}</tr>`;
     }).join('');
@@ -74,7 +75,8 @@ $(document).ready(function() {
       const row = [`${p.name}, ${p.unit}`];
       for (let i = 0; i < days.length; i++) {
         const v = values[i];
-        row.push(v !== undefined && v !== null ? Number(v).toLocaleString('en-US', { minimumFractionDigits: 1, maximumFractionDigits: 1, useGrouping: false }) : '');
+        const num = typeof v === 'string' ? parseFloat(v.replace(',', '.')) : v;
+        row.push(v !== undefined && v !== null && !isNaN(num) ? num.toLocaleString('bg-BG', { minimumFractionDigits: 1, maximumFractionDigits: 1, useGrouping: false }) : '');
       }
         csv.push(row.join(';'));
     });


### PR DESCRIPTION
## Summary
- Parse numeric strings with comma separators in monthly report table and CSV export
- Sanitize string values before writing to Excel templates to avoid locale issues
- Return report data formatted with decimal comma for UI and CSV display

## Testing
- `npm test` *(fails: Could not read package.json)*
- `python -m py_compile app.py`
- `node --check static/js/report.js`


------
https://chatgpt.com/codex/tasks/task_e_68c3c76dc1d8832899ee3e34e71e1073