### PR TITLE
Handle decimal comma in reports

### DIFF
--- a/mean_1h.py
+++ b/mean_1h.py
@@ -133,12 +133,11 @@ def populateMean1hour():
     mean_1hour_table=config.get('SQL', 'mean_1hour_table')
     # Insert output_data into the "mean1hour" table using the opened sqlalchemy engine
     try:
-        # NULL се замества с 0. Нужно ли е?
-        # Get the column names except the first and last columns
-        #columns_to_convert = output_data.columns[1:]
-
-        # Convert selected columns to float
-        #output_data[columns_to_convert] = output_data[columns_to_convert].astype(float)
+        # Ensure numeric columns use a dot decimal separator before writing
+        numeric_cols = output_data.columns.drop('DateRef')
+        output_data[numeric_cols] = output_data[numeric_cols].apply(
+            lambda s: pd.to_numeric(s.astype(str).str.replace(',', '.'), errors='coerce')
+        )
 
         # Now use to_sql() with your DataFrame
         output_data.to_sql(mean_1hour_table, con=engine, if_exists='append', index=False)

--- a/static/js/report.js
+++ b/static/js/report.js
@@ -29,7 +29,8 @@ $(document).ready(function() {
       const values = data[p.key] || [];
       const cells = days.map(d => {
         const v = values[d-1];
-        return `<td>${v !== undefined && v !== null ? Number(v).toLocaleString('bg-BG', { minimumFractionDigits: 1, maximumFractionDigits: 1 }) : ''}</td>`;
+        const num = typeof v === 'string' ? parseFloat(v.replace(',', '.')) : v;
+        return `<td>${v !== undefined && v !== null && !isNaN(num) ? num.toLocaleString('bg-BG', { minimumFractionDigits: 1, maximumFractionDigits: 1, useGrouping: false }) : ''}</td>`;
       }).join('');
       return `<tr><td class="sticky-col">${p.name}, ${p.unit}</td>${cells}</tr>`;
     }).join('');
@@ -74,7 +75,8 @@ $(document).ready(function() {
       const row = [`${p.name}, ${p.unit}`];
       for (let i = 0; i < days.length; i++) {
         const v = values[i];
-        row.push(v !== undefined && v !== null ? Number(v).toLocaleString('en-US', { minimumFractionDigits: 1, maximumFractionDigits: 1, useGrouping: false }) : '');
+        const num = typeof v === 'string' ? parseFloat(v.replace(',', '.')) : v;
+        row.push(v !== undefined && v !== null && !isNaN(num) ? num.toLocaleString('bg-BG', { minimumFractionDigits: 1, maximumFractionDigits: 1, useGrouping: false }) : '');
       }
         csv.push(row.join(';'));
     });


### PR DESCRIPTION
## Summary
- Parse numeric strings with comma separators in monthly report table and CSV export
- Sanitize string values before writing to Excel templates to avoid locale issues
- Return report data formatted with decimal comma for UI and CSV display
- Log missing database rows, unparsed numeric values and empty aggregates for monthly report generation
- Convert hourly mean DataFrame to use dot decimal separator before inserting into SQL

## Testing
- `npm test` *(fails: Could not read package.json)*
- `python -m py_compile app.py mean_1h.py`
- `node --check static/js/report.js`


------
https://chatgpt.com/codex/tasks/task_e_68c3c76dc1d8832899ee3e34e71e1073