### PR TITLE
Handle decimal comma in reports

### DIFF
--- a/insertMissingDataFromCSV.py
+++ b/insertMissingDataFromCSV.py
@@ -28,15 +28,12 @@ logger.addHandler(file_handler)
 
 file_handler = FileHandler('errorlog.txt')
 file_handler.setLevel(WARNING)
-
-DB_TABLE_HOUR = datetime.now()
 def call_mean_hourly(start_datetime, end_datetime):
     print(f"Calling mean_1h.py with range {start_datetime} to {end_datetime}")
     mean_1h.mean_1h(start_datetime, end_datetime)
 
 # Step 1: Read from config.ini file
 def read_config():
-    global DB_TABLE_HOUR
     # Load configuration from config.ini
     with open('config.ini', 'r', encoding='utf-8') as config_file:
         config = configparser.ConfigParser(interpolation=None)
@@ -52,7 +49,6 @@ def read_config():
         'table_name': config.get('SQL', 'DB_TABLE_MIN')
     }
 
-    DB_TABLE_HOUR = config.get('SQL', 'mean_1hour_table')
     # Read FTP config
     csv_cols = [col.strip() for col in config.get('CSV', 'csv_col_names').split(',')]
     db_cols = [col.strip() for col in config.get('CSV', 'db_col_names').split(',')]
@@ -219,7 +215,6 @@ def insert_data_into_db(engine, table_name, csv_data, column_mapping, db_col_nam
             print(f"Error inserting data into the database: {e}")
 
 def main():
-    global DB_TABLE_HOUR
     try:
         # Read config
         db_config, ftp_config = read_config()
@@ -260,9 +255,10 @@ def main():
         logging.error(f"Error connecting to FTP server or downloading files: {e}")
         return
 
-    # Initialize time range for new data
+    # Initialize tracking for newly inserted minute data
     earliest_new_datetime = None
     latest_new_datetime = None
+    new_hours = set()
 
     # Process and insert each downloaded CSV file
     for csv_file in os.listdir(local_csv_folder):
@@ -301,14 +297,22 @@ def main():
                 print(f"No new data in file {csv_file}. Skipping.")
                 continue
 
-            # Track earliest and latest DateRef in the new data
+            # Track the time span and affected hours for the new data
             current_min = csv_data_filtered['DateRef'].min()
             current_max = csv_data_filtered['DateRef'].max()
             earliest_new_datetime = current_min if earliest_new_datetime is None else min(earliest_new_datetime, current_min)
             latest_new_datetime = current_max if latest_new_datetime is None else max(latest_new_datetime, current_max)
 
+            new_hours.update(csv_data_filtered['DateRef'].dt.floor('H'))
+
             # Insert the filtered data into the database
-            insert_data_into_db(engine, db_config['table_name'], csv_data_filtered, ftp_config['column_mapping'], ftp_config['db_col_names'])
+            insert_data_into_db(
+                engine,
+                db_config['table_name'],
+                csv_data_filtered,
+                ftp_config['column_mapping'],
+                ftp_config['db_col_names'],
+            )
         except Exception as e:
             logging.error(f"Error processing file {csv_file}: {e}")
             continue
@@ -320,16 +324,12 @@ def main():
     #         result = connection.execute(query).scalar()
     #     return result
     try:
-        last_record_hour = get_last_record_datetime(engine, DB_TABLE_HOUR)
-        if isinstance(last_record_hour, str):
-            last_record_hour = datetime.strptime(last_record_hour.strip(), '%Y-%m-%d %H:%M:%S')
-
-        if earliest_new_datetime is not None and latest_new_datetime is not None:
-            hourly_start = last_record_hour.replace(minute=0, second=0, microsecond=0)
-            hourly_end = latest_new_datetime.replace(minute=0, second=0, microsecond=0)
-            if hourly_start < hourly_end:
-                hourly_end = hourly_end - timedelta(hours=1)
-                call_mean_hourly(hourly_start, hourly_end)
+        if new_hours:
+            current_hour = datetime.now().replace(minute=0, second=0, microsecond=0)
+            for hour in sorted(new_hours):
+                hour_dt = hour.to_pydatetime() if hasattr(hour, 'to_pydatetime') else hour
+                if hour_dt < current_hour:
+                    call_mean_hourly(hour_dt, hour_dt)
         else:
             return "No new data inserted; skipping hourly mean calculation."
     except Exception as e:

--- a/mean_1h.py
+++ b/mean_1h.py
@@ -133,12 +133,11 @@ def populateMean1hour():
     mean_1hour_table=config.get('SQL', 'mean_1hour_table')
     # Insert output_data into the "mean1hour" table using the opened sqlalchemy engine
     try:
-        # NULL се замества с 0. Нужно ли е?
-        # Get the column names except the first and last columns
-        #columns_to_convert = output_data.columns[1:]
-
-        # Convert selected columns to float
-        #output_data[columns_to_convert] = output_data[columns_to_convert].astype(float)
+        # Ensure numeric columns use a dot decimal separator before writing
+        numeric_cols = output_data.columns.drop('DateRef')
+        output_data[numeric_cols] = output_data[numeric_cols].apply(
+            lambda s: pd.to_numeric(s.astype(str).str.replace(',', '.'), errors='coerce')
+        )
 
         # Now use to_sql() with your DataFrame
         output_data.to_sql(mean_1hour_table, con=engine, if_exists='append', index=False)

--- a/static/js/report.js
+++ b/static/js/report.js
@@ -29,7 +29,8 @@ $(document).ready(function() {
       const values = data[p.key] || [];
       const cells = days.map(d => {
         const v = values[d-1];
-        return `<td>${v !== undefined && v !== null ? Number(v).toLocaleString('bg-BG', { minimumFractionDigits: 1, maximumFractionDigits: 1 }) : ''}</td>`;
+        const num = typeof v === 'string' ? parseFloat(v.replace(',', '.')) : v;
+        return `<td>${v !== undefined && v !== null && !isNaN(num) ? num.toLocaleString('bg-BG', { minimumFractionDigits: 1, maximumFractionDigits: 1, useGrouping: false }) : ''}</td>`;
       }).join('');
       return `<tr><td class="sticky-col">${p.name}, ${p.unit}</td>${cells}</tr>`;
     }).join('');
@@ -74,7 +75,8 @@ $(document).ready(function() {
       const row = [`${p.name}, ${p.unit}`];
       for (let i = 0; i < days.length; i++) {
         const v = values[i];
-        row.push(v !== undefined && v !== null ? Number(v).toLocaleString('en-US', { minimumFractionDigits: 1, maximumFractionDigits: 1, useGrouping: false }) : '');
+        const num = typeof v === 'string' ? parseFloat(v.replace(',', '.')) : v;
+        row.push(v !== undefined && v !== null && !isNaN(num) ? num.toLocaleString('bg-BG', { minimumFractionDigits: 1, maximumFractionDigits: 1, useGrouping: false }) : '');
       }
         csv.push(row.join(';'));
     });


### PR DESCRIPTION
## Summary
- Parse numeric strings with comma separators in monthly report table and CSV export
- Sanitize string values before writing to Excel templates to avoid locale issues
- Return report data formatted with decimal comma for UI and CSV display
- Log missing database rows, unparsed numeric values and empty aggregates for monthly report generation
- Convert hourly mean DataFrame to use dot decimal separator before inserting into SQL
- Trigger hourly mean computation only for hours with newly inserted CSV data

## Testing
- `npm test` *(fails: Could not read package.json)*
- `python -m py_compile app.py mean_1h.py insertMissingDataFromCSV.py`
- `node --check static/js/report.js`


------
https://chatgpt.com/codex/tasks/task_e_68c3c76dc1d8832899ee3e34e71e1073