### PR TITLE
Format monthly report numbers and ensure hourly mean

### DIFF
--- a/app.py
+++ b/app.py
@@ -663,6 +663,12 @@ def report_data_endpoint():
 
         combined = combined.round(1)
 
+        now = datetime.now()
+        if year == now.year and month == now.month:
+            today = now.date()
+            if today in combined.index:
+                combined.loc[today] = np.nan
+
         for col in combined.columns:
             if combined[col].isna().all():
                 logger.error(
@@ -672,10 +678,10 @@ def report_data_endpoint():
                     month,
                 )
 
-        def format_val(v):
-            return f"{v:.1f}".replace('.', ',') if pd.notnull(v) else None
-
-        result = {col: [format_val(v) for v in combined[col]] for col in combined.columns}
+        result = {
+            col: [None if pd.isna(v) else float(v) for v in combined[col]]
+            for col in combined.columns
+        }
         return jsonify(result)
     except Exception as e:
         logger.error(f"Error in /report_data endpoint: {e}", exc_info=True)

--- a/static/js/report.js
+++ b/static/js/report.js
@@ -27,11 +27,11 @@ $(document).ready(function() {
     $('#report-table thead').html(thead);
     let rows = params.map(p => {
       const values = data[p.key] || [];
-      const cells = days.map(d => {
-        const v = values[d-1];
-        const num = typeof v === 'string' ? parseFloat(v.replace(',', '.')) : v;
-        return `<td>${v !== undefined && v !== null && !isNaN(num) ? num.toLocaleString('bg-BG', { minimumFractionDigits: 1, maximumFractionDigits: 1, useGrouping: false }) : ''}</td>`;
-      }).join('');
+        const cells = days.map(d => {
+          const v = values[d-1];
+          const num = typeof v === 'number' ? v : parseFloat(String(v).replace(',', '.'));
+          return `<td>${v !== undefined && v !== null && !isNaN(num) ? num.toLocaleString('bg-BG', { minimumFractionDigits: 1, maximumFractionDigits: 1, useGrouping: true }) : ''}</td>`;
+        }).join('');
       return `<tr><td class="sticky-col">${p.name}, ${p.unit}</td>${cells}</tr>`;
     }).join('');
     $('#report-table tbody').html(rows);
@@ -73,11 +73,11 @@ $(document).ready(function() {
     params.forEach(p => {
       const values = currentData[p.key] || [];
       const row = [`${p.name}, ${p.unit}`];
-      for (let i = 0; i < days.length; i++) {
-        const v = values[i];
-        const num = typeof v === 'string' ? parseFloat(v.replace(',', '.')) : v;
-        row.push(v !== undefined && v !== null && !isNaN(num) ? num.toLocaleString('bg-BG', { minimumFractionDigits: 1, maximumFractionDigits: 1, useGrouping: false }) : '');
-      }
+        for (let i = 0; i < days.length; i++) {
+          const v = values[i];
+          const num = typeof v === 'number' ? v : parseFloat(String(v).replace(',', '.'));
+          row.push(v !== undefined && v !== null && !isNaN(num) ? num.toLocaleString('bg-BG', { minimumFractionDigits: 1, maximumFractionDigits: 1, useGrouping: true }) : '');
+        }
         csv.push(row.join(';'));
     });
     const csvContent = csv.join('\n');


### PR DESCRIPTION
## Summary
- Format monthly report numbers with thousand separators and hide partial current-day data
- Compute missing hourly means after inserting new minute data

## Testing
- `python -m py_compile app.py insertMissingDataFromCSV.py`


------
https://chatgpt.com/codex/tasks/task_e_68c7c1de43688328af9d2ae5877161d4