### PR TITLE
Format monthly report numbers and ensure hourly mean

### DIFF
--- a/insertMissingDataFromCSV.py
+++ b/insertMissingDataFromCSV.py
@@ -256,10 +256,8 @@ def main():
         logging.error(f"Error connecting to FTP server or downloading files: {e}")
         return
 
-    # Initialize tracking for newly inserted minute data
-    earliest_new_datetime = None
+    # Track the latest timestamp from newly inserted minute data
     latest_new_datetime = None
-    new_hours = set()
 
     # Process and insert each downloaded CSV file
     for csv_file in os.listdir(local_csv_folder):
@@ -298,13 +296,10 @@ def main():
                 print(f"No new data in file {csv_file}. Skipping.")
                 continue
 
-            # Track the time span and affected hours for the new data
-            current_min = csv_data_filtered['DateRef'].min()
+            # Track the latest timestamp for the new data
             current_max = csv_data_filtered['DateRef'].max()
-            earliest_new_datetime = current_min if earliest_new_datetime is None else min(earliest_new_datetime, current_min)
-            latest_new_datetime = current_max if latest_new_datetime is None else max(latest_new_datetime, current_max)
-
-            new_hours.update(csv_data_filtered['DateRef'].dt.floor('H'))
+            if latest_new_datetime is None or current_max > latest_new_datetime:
+                latest_new_datetime = current_max
 
             # Insert the filtered data into the database
             insert_data_into_db(
@@ -318,42 +313,27 @@ def main():
             logging.error(f"Error processing file {csv_file}: {e}")
             continue
 
-    # # Step 3: Find the last record in the DB
-    # def get_last_record_datetime(engine, table_name):
-    #     query = text(f"SELECT MAX(`DateRef`) FROM {table_name}")
-    #     with engine.connect() as connection:
-    #         result = connection.execute(query).scalar()
-    #     return result
     try:
-        boundary_hour = datetime.now().replace(minute=0, second=0, microsecond=0)
         hourly_table = db_config['hourly_table']
-        raw_table = db_config['table_name']
-        last_hourly_dt = get_last_record_datetime(engine, hourly_table)
-        start_hour = (
-            last_hourly_dt
-            if last_hourly_dt is not None
-            else (earliest_new_datetime.floor('H') if earliest_new_datetime is not None else None)
-        )
-        if start_hour is None:
-            return "No new data inserted; skipping hourly mean calculation."
-        current_hour = start_hour
-        while current_hour < boundary_hour:
-            hour_end = current_hour + timedelta(hours=1)
-            with engine.connect() as conn:
-                has_raw = conn.execute(
-                    text(
-                        f"SELECT 1 FROM {raw_table} "
-                        "WHERE DateRef >= :start AND DateRef < :end LIMIT 1"
-                    ),
-                    {"start": current_hour, "end": hour_end}
-                ).scalar()
-                has_mean = conn.execute(
-                    text(f"SELECT 1 FROM {hourly_table} WHERE DateRef = :dt LIMIT 1"),
-                    {"dt": hour_end}
-                ).scalar()
-            if has_raw and not has_mean:
-                call_mean_hourly(current_hour, current_hour)
-            current_hour = hour_end
+        last_hour_record = get_last_record_datetime(engine, hourly_table)
+        if last_hour_record is None:
+            last_hour_record = datetime.min
+        last_hour_record = last_hour_record.replace(minute=0, second=0, microsecond=0)
+        if latest_new_datetime is not None:
+            last_complete_hour = (
+                latest_new_datetime.replace(minute=0, second=0, microsecond=0)
+                - timedelta(hours=1)
+            )
+            hour = last_hour_record
+            while hour < last_complete_hour:
+                hour += timedelta(hours=1)
+                with engine.connect() as conn:
+                    has_mean = conn.execute(
+                        text(f"SELECT 1 FROM {hourly_table} WHERE DateRef = :dt LIMIT 1"),
+                        {"dt": hour}
+                    ).scalar()
+                if not has_mean:
+                    call_mean_hourly(hour, hour)
     except Exception as e:
         logging.error(f"Error calculating hourly mean: {e}")
         print(e)

--- a/static/js/report.js
+++ b/static/js/report.js
@@ -27,11 +27,11 @@ $(document).ready(function() {
     $('#report-table thead').html(thead);
     let rows = params.map(p => {
       const values = data[p.key] || [];
-      const cells = days.map(d => {
-        const v = values[d-1];
-        const num = typeof v === 'string' ? parseFloat(v.replace(',', '.')) : v;
-        return `<td>${v !== undefined && v !== null && !isNaN(num) ? num.toLocaleString('bg-BG', { minimumFractionDigits: 1, maximumFractionDigits: 1, useGrouping: false }) : ''}</td>`;
-      }).join('');
+        const cells = days.map(d => {
+          const v = values[d-1];
+          const num = typeof v === 'number' ? v : parseFloat(String(v).replace(',', '.'));
+          return `<td>${v !== undefined && v !== null && !isNaN(num) ? num.toLocaleString('bg-BG', { minimumFractionDigits: 1, maximumFractionDigits: 1, useGrouping: true }) : ''}</td>`;
+        }).join('');
       return `<tr><td class="sticky-col">${p.name}, ${p.unit}</td>${cells}</tr>`;
     }).join('');
     $('#report-table tbody').html(rows);
@@ -73,11 +73,11 @@ $(document).ready(function() {
     params.forEach(p => {
       const values = currentData[p.key] || [];
       const row = [`${p.name}, ${p.unit}`];
-      for (let i = 0; i < days.length; i++) {
-        const v = values[i];
-        const num = typeof v === 'string' ? parseFloat(v.replace(',', '.')) : v;
-        row.push(v !== undefined && v !== null && !isNaN(num) ? num.toLocaleString('bg-BG', { minimumFractionDigits: 1, maximumFractionDigits: 1, useGrouping: false }) : '');
-      }
+        for (let i = 0; i < days.length; i++) {
+          const v = values[i];
+          const num = typeof v === 'number' ? v : parseFloat(String(v).replace(',', '.'));
+          row.push(v !== undefined && v !== null && !isNaN(num) ? num.toLocaleString('bg-BG', { minimumFractionDigits: 1, maximumFractionDigits: 1, useGrouping: true }) : '');
+        }
         csv.push(row.join(';'));
     });
     const csvContent = csv.join('\n');


### PR DESCRIPTION
## Summary
- Leave blank daily totals when no minute data exists and exclude the current day's partial readings from the monthly report
- After importing minute data, compute missing hourly means only through the last fully completed hour

## Testing
- `python -m py_compile app.py insertMissingDataFromCSV.py`


------
https://chatgpt.com/codex/tasks/task_e_68c7c1de43688328af9d2ae5877161d4