### PR TITLE
Compute rainfall aggregates and display alarms banner

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -24,3 +24,10 @@ csv_template_name= data_dp_
 csv_col_names=Time,T_AIR[C],T_INSIDE[C],REL_HUM[perc],RADIATION[W/m2],EVAPOR_MINUTE[mm/min],WIND_SPEED_1[km/h],WIND_SPEED_2[m/s],WIND_DIR[DEG],WIND_GUST[km/h],P_ABS[hPa],P_REL[hPa],RAIN_MINUTE[mm],RAIN_HOUR[mm/h],T_WATER[C],DEW_POINT[C]
 db_col_names=DateRef,T_AIR,T_INSIDE,REL_HUM,RADIATION,EVAPOR_MINUTE,WIND_SPEED_1,WIND_SPEED_2,WIND_DIR,WIND_GUST,P_ABS,P_REL,RAIN_MINUTE,RAIN_HOUR,T_WATER,DEW_POINT
 local_csv_folder = ./downloaded_csvs  # Local folder for saving downloaded files
+
+[ALARMS]
+table = alarms
+date_column = DateRef
+columns = POWER_BAD,DOOR1_OP,DOOR2_OP,FIRE_ALARM,HIGH_TEMP
+columns_names = Захранване,Врата 1,Врата 2,Пожарна аларма,Висока температура
+columns_descriptions = Връзка със захранването - нарушена,Врата 1 - отворена,Врата 2 - отворена,Огнена аларма активна,Превишена температура в шкафа

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -9,6 +9,7 @@ body {
   background-size: cover;
   background-attachment: fixed;
   background-repeat: no-repeat;
+  padding-bottom: 90px;
 }
 
 /* Banner section */
@@ -61,6 +62,10 @@ body {
 
 .logout-btn:hover {
   background-color: #3b8e63;
+}
+
+.hidden {
+  display: none !important;
 }
 
 /* Container Styling */
@@ -198,6 +203,44 @@ body {
     #statistics-container {
         grid-template-columns: 1fr;
     }
+}
+
+.alarm-banner {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  background: rgba(178, 34, 34, 0.95);
+  color: #fff;
+  padding: 12px 20px;
+  box-shadow: 0 -2px 6px rgba(0, 0, 0, 0.2);
+  z-index: 1000;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  align-items: center;
+}
+
+.alarm-title {
+  font-weight: bold;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}
+
+.alarm-messages {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 10px;
+}
+
+.alarm-message {
+  background: rgba(255, 255, 255, 0.2);
+  border: 1px solid rgba(255, 255, 255, 0.4);
+  border-radius: 4px;
+  padding: 6px 12px;
+  font-weight: 600;
+  text-align: center;
 }
 
 #statistics-container .dashboard-card,

--- a/static/js/scripts.js
+++ b/static/js/scripts.js
@@ -156,6 +156,44 @@ $(document).ready(function () {
 
     }
 
+    function updateAlarmBanner(alarms, ftpOk) {
+        const banner = $('#alarm-banner');
+        const messagesContainer = $('#alarm-messages');
+        const messages = [];
+
+        if (Array.isArray(alarms)) {
+            alarms.forEach(alarm => {
+                if (!alarm) return;
+                const name = alarm.name || alarm.column || '';
+                const description = alarm.description || '';
+                const parts = [];
+                if (name) {
+                    parts.push(name);
+                }
+                if (description && description !== name) {
+                    parts.push(description);
+                }
+                const text = parts.join(' - ').trim();
+                if (text) {
+                    messages.push(text);
+                }
+            });
+        }
+
+        if (ftpOk === false) {
+            messages.push('Връзка с контролера - нарушена');
+        }
+
+        if (messages.length) {
+            const html = messages.map(msg => `<div class="alarm-message">${msg}</div>`).join('');
+            messagesContainer.html(html);
+            banner.removeClass('hidden');
+        } else {
+            messagesContainer.empty();
+            banner.addClass('hidden');
+        }
+    }
+
     function fetchMomentData() {
         $.ajax({
             type: 'GET',
@@ -166,6 +204,7 @@ $(document).ready(function () {
                     console.error("Error in API response:", response.error);
                     return;
                 }
+                updateAlarmBanner(response.alarms, response.ftp_connection_ok);
                 if (response.min_values_data && response.min_values_data.length > 0) {
                     renderDashboard(
                         response.min_values_data[0],

--- a/templates/index.html
+++ b/templates/index.html
@@ -36,5 +36,10 @@
     </div>
   </div>
 
+  <div id="alarm-banner" class="alarm-banner hidden">
+    <div class="alarm-title">Аларми</div>
+    <div id="alarm-messages" class="alarm-messages"></div>
+  </div>
+
 </body>
 </html>


### PR DESCRIPTION
## Summary
- calculate hourly, daily, monthly, and yearly rainfall totals from minute data using SQL sums before populating the live dashboard
- load alarm metadata from configuration, fetch active alarms (including FTP connectivity status), and expose them in the moment data API
- surface alarms on the moment data page with a persistent banner and accompanying styles

## Testing
- python -m compileall app.py insertMissingDataFromCSV.py

------
https://chatgpt.com/codex/tasks/task_e_68ca4a2cc7888328a3314ff192528da3