### PR TITLE
Align wind processing with calculate_wind_stats helper

### DIFF
--- a/mean_1h.py
+++ b/mean_1h.py
@@ -7,6 +7,8 @@ import sys
 import numpy as np
 import configparser
 
+from wind_utils import calculate_wind_stats
+
 # Load configuration from config.ini
 with open('config.ini', 'r', encoding='utf-8') as config_file:
     config = configparser.ConfigParser(interpolation=None)
@@ -113,6 +115,36 @@ def makeHourData():
             lambda s: pd.to_numeric(s.astype(str).str.replace(',', '.'), errors='coerce')
         )
         mean_values = numeric.mean().round(4)
+
+        wind_direction_mean = float('nan')
+        if 'WIND_DIR' in numeric.columns:
+            direction_series = numeric['WIND_DIR']
+            wind_speed_columns = [
+                col for col in numeric.columns if col.startswith('WIND_SPEED')
+            ]
+            for speed_col in wind_speed_columns:
+                stats_df = pd.DataFrame({
+                    speed_col: numeric[speed_col],
+                    'WIND_DIR': direction_series,
+                })
+                stats = calculate_wind_stats(stats_df, speed_col=speed_col, dir_col='WIND_DIR')
+                if not np.isnan(stats.mean_speed_resultant):
+                    mean_values[speed_col] = round(stats.mean_speed_resultant, 4)
+                if np.isnan(wind_direction_mean) and not np.isnan(stats.mean_dir):
+                    wind_direction_mean = stats.mean_dir
+
+            if np.isnan(wind_direction_mean):
+                direction_only_df = pd.DataFrame({
+                    '_unit_speed': np.where(direction_series.notna(), 1.0, np.nan),
+                    'WIND_DIR': direction_series,
+                })
+                direction_stats = calculate_wind_stats(
+                    direction_only_df, speed_col='_unit_speed', dir_col='WIND_DIR'
+                )
+                wind_direction_mean = direction_stats.mean_dir
+
+            if not np.isnan(wind_direction_mean):
+                mean_values['WIND_DIR'] = round(wind_direction_mean, 2)
         if 'RAIN' in numeric.columns:
             rain_series = numeric['RAIN'].dropna()
             rain_total = float(rain_series.sum()) if not rain_series.empty else 0.0

--- a/wind_utils.py
+++ b/wind_utils.py
@@ -1,0 +1,97 @@
+"""Utility helpers for computing wind speed and direction statistics."""
+from __future__ import annotations
+from dataclasses import dataclass
+
+import numpy as np
+import pandas as pd
+
+
+@dataclass
+class WindStats:
+    """Container for aggregated wind statistics."""
+
+    mean_speed_scalar: float
+    mean_speed_resultant: float
+    mean_dir: float
+    R: float
+
+    def to_dict(self) -> dict:
+        return {
+            "mean_speed_scalar": self.mean_speed_scalar,
+            "mean_speed_resultant": self.mean_speed_resultant,
+            "mean_dir": self.mean_dir,
+            "R": self.R,
+        }
+
+
+def _prepare_wind_components(
+    speeds: pd.Series, directions: pd.Series
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Prepare filtered speed and direction arrays and their radian representation."""
+    speeds_values = pd.to_numeric(speeds, errors="coerce").to_numpy(dtype=float)
+    directions_values = pd.to_numeric(directions, errors="coerce").to_numpy(dtype=float)
+
+    valid_mask = (~np.isnan(speeds_values)) & (~np.isnan(directions_values))
+    return speeds_values, directions_values, np.radians(directions_values[valid_mask])
+
+
+def calculate_wind_stats(
+    df: pd.DataFrame,
+    speed_col: str = "WIND_SPEED",
+    dir_col: str = "WIND_ANGLE",
+) -> WindStats:
+    """Calculate aggregated wind statistics for the provided dataframe.
+
+    Parameters
+    ----------
+    df:
+        DataFrame containing wind data.
+    speed_col:
+        Column name containing wind speed values (m/s).
+    dir_col:
+        Column name containing wind direction values (degrees).
+
+    Returns
+    -------
+    WindStats
+        Dataclass with scalar mean speed, resultant mean speed, mean direction and
+        the consistency coefficient ``R``.
+    """
+    if speed_col not in df.columns or dir_col not in df.columns:
+        return WindStats(np.nan, np.nan, np.nan, np.nan)
+
+    speeds_values, directions_values, rad = _prepare_wind_components(
+        df[speed_col], df[dir_col]
+    )
+
+    valid_mask = (~np.isnan(speeds_values)) & (~np.isnan(directions_values))
+
+    if not np.any(valid_mask):
+        if speeds_values.size == 0 or np.all(np.isnan(speeds_values)):
+            scalar_mean = np.nan
+        else:
+            scalar_mean = float(np.nanmean(speeds_values))
+        return WindStats(scalar_mean, np.nan, np.nan, np.nan)
+
+    speeds_valid = speeds_values[valid_mask]
+
+    u = speeds_valid * np.cos(rad)
+    v = speeds_valid * np.sin(rad)
+
+    u_mean = u.mean() if u.size else np.nan
+    v_mean = v.mean() if v.size else np.nan
+
+    resultant_speed = float(np.sqrt(u_mean**2 + v_mean**2)) if u.size else np.nan
+    mean_direction = float((np.degrees(np.arctan2(v_mean, u_mean))) % 360) if u.size else np.nan
+
+    if speeds_values.size == 0 or np.all(np.isnan(speeds_values)):
+        scalar_mean = np.nan
+    else:
+        scalar_mean = float(np.nanmean(speeds_values))
+
+    if np.isnan(resultant_speed) or np.isnan(scalar_mean) or scalar_mean == 0:
+        consistency = np.nan
+    else:
+        consistency = resultant_speed / scalar_mean
+
+    return WindStats(scalar_mean, resultant_speed, mean_direction, consistency)


### PR DESCRIPTION
## Summary
- replace the wind utilities module with the provided `calculate_wind_stats` helper and dataclass
- update the hourly aggregation script and Flask app to source wind speed and direction averages from the shared helper

## Testing
- `python - <<'PY'
import pandas as pd
import numpy as np
from wind_utils import calculate_wind_stats
from app import _wind_vector_resample

# Test calculate_wind_stats with typical data
sample = pd.DataFrame({
    'WIND_SPEED_1': [5, 5, np.nan, 10],
    'WIND_DIR': [350, 10, 20, 5],
})
stats = calculate_wind_stats(sample, speed_col='WIND_SPEED_1', dir_col='WIND_DIR')
print('stats', stats)

# Test fallback direction averaging with missing speeds
only_dir = pd.DataFrame({'WIND_DIR': [350, 10, np.nan, 20]})
only_dir['_unit_speed'] = np.where(only_dir['WIND_DIR'].notna(), 1.0, np.nan)
print('direction only', calculate_wind_stats(only_dir, speed_col='_unit_speed', dir_col='WIND_DIR'))

# Test resampling helper
index = pd.date_range('2024-01-01', periods=4, freq='15min')
df = pd.DataFrame({
    'WIND_SPEED_1': [10, 10, 0, 5],
    'WIND_SPEED_2': [4, 4, 0, 2],
    'WIND_DIR': [0, 90, 180, 270],
}, index=index)
resampled = _wind_vector_resample(df, 'H')
print(resampled)
PY`


------
https://chatgpt.com/codex/tasks/task_e_68de1ee356b48328b2dafc01f2d0ebac