### PR TITLE
Fix monthly report query and support PyInstaller resource paths

### DIFF
--- a/app.py
+++ b/app.py
@@ -43,6 +43,21 @@ from logging import FileHandler, WARNING
 import threading
 import time
 current_dir = os.path.dirname(os.path.abspath(__file__))
+
+
+def resource_path(relative_path: str) -> str:
+    """Resolve resource paths for both source and PyInstaller builds."""
+    candidates = []
+    if hasattr(sys, '_MEIPASS'):
+        candidates.append(os.path.join(sys._MEIPASS, relative_path))
+    if getattr(sys, 'frozen', False):
+        candidates.append(os.path.join(os.path.dirname(sys.executable), relative_path))
+    candidates.append(os.path.join(current_dir, relative_path))
+
+    for path in candidates:
+        if os.path.exists(path):
+            return path
+    return candidates[-1]
 # Create a logger
 logger = logging.getLogger()
 logger.setLevel(logging.DEBUG)
@@ -231,9 +246,8 @@ def get_active_alarms():
 
 #INitialize plot
 
-STATIC_FOLDER = os.path.join(current_dir, 'static')
-#TEMPLATES_FOLDER = os.path.join(current_dir, 'templates')
-template_dir = os.path.abspath('templates')
+STATIC_FOLDER = resource_path('static')
+template_dir = resource_path('templates')
 app = Flask(__name__, static_folder=STATIC_FOLDER, template_folder=template_dir)
 #app = Flask(__name__, template_folder=template_dir)
 #app = Flask(__name__)
@@ -1072,7 +1086,7 @@ def report_data_endpoint():
     year = request.args.get('year', type=int)
     month = request.args.get('month', type=int)
 
-    today_day = datetime.today().day
+    today = datetime.today().date()
     if not year or not month:
         return jsonify({})
     try:
@@ -1101,10 +1115,13 @@ def report_data_endpoint():
         query = (
             f"SELECT {DATE_COLUMN}, {', '.join(cols)} FROM {DB_TABLE} "
             f"WHERE YEAR({DATE_COLUMN}) = %s AND MONTH({DATE_COLUMN}) = %s "
-            f"AND DAY({DATE_COLUMN}) < %s "
-            f"ORDER BY {DATE_COLUMN} ASC"
         )
-        cursor.execute(query, (year, month, today_day))
+        params = [year, month]
+        if year == today.year and month == today.month:
+            query += f"AND DATE({DATE_COLUMN}) < %s "
+            params.append(today)
+        query += f"ORDER BY {DATE_COLUMN} ASC"
+        cursor.execute(query, params)
         data = cursor.fetchall()
         cursor.close()
         db_connection.close()

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -591,8 +591,6 @@ body {
   background: #fff;
   padding: 10px;
   border-radius: 8px;
-  display: flex;
-  justify-content: center;
 }
 
 #report-table {
@@ -601,7 +599,7 @@ body {
   min-width: 0;
   font-size: 12px;
   background: #fff;
-  margin: 0 auto;
+  margin: 0;
 }
 
 #report-table th,
@@ -618,6 +616,10 @@ body {
   background: #62bf8f;
   color: #fff;
   z-index: 2;
+}
+
+#report-table thead th.sticky-col {
+  z-index: 4;
 }
 
 #report-table thead th {


### PR DESCRIPTION
## Summary
- resolve static and template directories dynamically so the app works when bundled without extra PyInstaller data arguments
- correct the monthly report query to include all days for past months while still skipping the current day when needed
- tweak report table styling so the parameter column stays fixed on the left

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_68de3bbfd7a883288150cb2ae368f0cd