### PR TITLE
Fix hourly aggregation boundaries to prevent duplicates

### DIFF
--- a/insertMissingDataFromCSV.py
+++ b/insertMissingDataFromCSV.py
@@ -342,16 +342,20 @@ def main():
         hourly_table = db_config['hourly_table']
         last_hour_record = get_last_record_datetime(engine, hourly_table)
         if latest_new_datetime is not None:
-            last_record_hour_minus_one = (
+            latest_completed_hour = (
                 latest_new_datetime.replace(minute=0, second=0, microsecond=0)
                 - timedelta(hours=1)
             )
             if last_hour_record is None:
-                current_hour = last_record_hour_minus_one
+                current_hour = latest_completed_hour
             else:
-                current_hour = last_hour_record.replace(minute=0, second=0, microsecond=0)
-            while current_hour < last_record_hour_minus_one:
-                call_mean_hourly(current_hour, current_hour + timedelta(hours=1))
+                current_hour = (
+                    last_hour_record.replace(minute=0, second=0, microsecond=0)
+                    + timedelta(hours=1)
+                )
+
+            while current_hour is not None and current_hour <= latest_completed_hour:
+                call_mean_hourly(current_hour, current_hour)
                 current_hour += timedelta(hours=1)
     except Exception as e:
         logging.error(f"Error calculating hourly mean: {e}")

--- a/mean_1h.py
+++ b/mean_1h.py
@@ -240,10 +240,10 @@ def mean_1h(start_datetime, end_datetime):
     current_hour = _hour_start(start_datetime).replace(second=0, microsecond=0)
     end_hour = _hour_start(end_datetime).replace(second=0, microsecond=0)
 
-    if end_hour < current_hour:
-        end_hour = current_hour
+    if end_hour <= current_hour:
+        end_hour = current_hour + timedelta(hours=1)
 
-    while current_hour <= end_hour:
+    while current_hour < end_hour:
         hour_end = current_hour + timedelta(hours=1)
         if datetime.now() < hour_end:
             print(f"Hour starting at {current_hour} not finished; skipping")


### PR DESCRIPTION
## Summary
- ensure hourly aggregation restarts from the first new hour and invokes mean_1h with an exclusive end
- adjust mean_1h loop to treat the end boundary as exclusive when iterating hours

## Testing
- python -m py_compile insertMissingDataFromCSV.py mean_1h.py

------
https://chatgpt.com/codex/tasks/task_e_68de542403a08328bdb3648fbad60820