### PR TITLE
Refine hourly aggregation window selection

### DIFF
--- a/insertMissingDataFromCSV.py
+++ b/insertMissingDataFromCSV.py
@@ -282,6 +282,7 @@ def main():
         return
 
     # Track the latest timestamp from newly inserted minute data
+    earliest_new_datetime = None
     latest_new_datetime = None
 
     # Process and insert each downloaded CSV file
@@ -321,7 +322,10 @@ def main():
                 print(f"No new data in file {csv_file}. Skipping.")
                 continue
 
-            # Track the latest timestamp for the new data
+            # Track the timestamp range for the new data
+            current_min = csv_data_filtered['DateRef'].min()
+            if earliest_new_datetime is None or current_min < earliest_new_datetime:
+                earliest_new_datetime = current_min
             current_max = csv_data_filtered['DateRef'].max()
             if latest_new_datetime is None or current_max > latest_new_datetime:
                 latest_new_datetime = current_max
@@ -342,15 +346,29 @@ def main():
         hourly_table = db_config['hourly_table']
         last_hour_record = get_last_record_datetime(engine, hourly_table)
         if latest_new_datetime is not None:
-            last_record_hour_minus_one = (
+            latest_completed_hour = (
                 latest_new_datetime.replace(minute=0, second=0, microsecond=0)
                 - timedelta(hours=1)
             )
-            if last_hour_record is None:
-                current_hour = last_record_hour_minus_one
+
+            if earliest_new_datetime is None:
+                first_unprocessed_hour = latest_completed_hour
             else:
-                current_hour = last_hour_record.replace(minute=0, second=0, microsecond=0)
-            while current_hour < last_record_hour_minus_one:
+                first_unprocessed_hour = earliest_new_datetime.replace(
+                    minute=0, second=0, microsecond=0
+                )
+
+            if last_hour_record is not None:
+                current_hour = (
+                    last_hour_record.replace(minute=0, second=0, microsecond=0)
+                    + timedelta(hours=1)
+                )
+                if current_hour < first_unprocessed_hour:
+                    current_hour = first_unprocessed_hour
+            else:
+                current_hour = first_unprocessed_hour
+
+            while current_hour is not None and current_hour <= latest_completed_hour:
                 call_mean_hourly(current_hour, current_hour + timedelta(hours=1))
                 current_hour += timedelta(hours=1)
     except Exception as e:

--- a/mean_1h.py
+++ b/mean_1h.py
@@ -240,10 +240,10 @@ def mean_1h(start_datetime, end_datetime):
     current_hour = _hour_start(start_datetime).replace(second=0, microsecond=0)
     end_hour = _hour_start(end_datetime).replace(second=0, microsecond=0)
 
-    if end_hour < current_hour:
-        end_hour = current_hour
+    if end_hour <= current_hour:
+        end_hour = current_hour + timedelta(hours=1)
 
-    while current_hour <= end_hour:
+    while current_hour < end_hour:
         hour_end = current_hour + timedelta(hours=1)
         if datetime.now() < hour_end:
             print(f"Hour starting at {current_hour} not finished; skipping")


### PR DESCRIPTION
## Summary
- track the earliest timestamp of freshly inserted minute data to identify the first pending hour
- align the hourly recomputation loop to start from that hour and invoke mean_1h with an exclusive end boundary

## Testing
- python -m py_compile insertMissingDataFromCSV.py mean_1h.py

------
https://chatgpt.com/codex/tasks/task_e_68de542403a08328bdb3648fbad60820