### PR TITLE
Align solar radiation sum within statistics columns

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -285,13 +285,21 @@ body {
   color: #333;
 }
 /* Statistics lists */
+.stats-columns {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+}
+
+.stats-column {
+  flex: 1 1 220px;
+}
+
 .stats-list {
   list-style: none;
   padding: 0;
   margin: 0;
   text-align: left;
-  display: flex;
-  flex-wrap: wrap;
 }
 
 .stats-item {
@@ -300,7 +308,6 @@ body {
   gap: 4px;
   padding: 2px 4px;
   border-bottom: 1px solid #e0e0e0;
-  width: 50%;
 }
 
 .stats-item:last-child {

--- a/static/js/statistics.js
+++ b/static/js/statistics.js
@@ -1,23 +1,38 @@
 $(document).ready(function () {
-  function listToHtml(items) {
+  function renderList(items) {
+    if (!items || !items.length) {
+      return '';
+    }
     return (
       '<ul class="stats-list">' +
       items
-        .map(
-          item => {
-            const valueHtml = Array.isArray(item.value)
-              ? item.value
-                  .map(v => `<span class="stats-subvalue">${v}</span>`)
-                  .join('')
-              : item.value;
-            return (
-              `<li class="stats-item"><span class="stats-label">${item.label}</span>` +
-              `<span class="stats-value">${valueHtml}</span></li>`
-            );
-          }
-        )
+        .map(item => {
+          const valueHtml = Array.isArray(item.value)
+            ? item.value
+                .map(v => `<span class="stats-subvalue">${v}</span>`)
+                .join('')
+            : item.value;
+          return (
+            `<li class="stats-item"><span class="stats-label">${item.label}</span>` +
+            `<span class="stats-value">${valueHtml}</span></li>`
+          );
+        })
         .join('') +
       '</ul>'
+    );
+  }
+
+  function groupToHtml(grouped) {
+    if (!grouped) {
+      return '';
+    }
+    const leftHtml = renderList(grouped.left || []);
+    const rightHtml = renderList(grouped.right || []);
+    return (
+      '<div class="stats-columns">' +
+      `<div class="stats-column stats-column-left">${leftHtml}</div>` +
+      `<div class="stats-column stats-column-right">${rightHtml}</div>` +
+      '</div>'
     );
   }
 
@@ -25,10 +40,10 @@ $(document).ready(function () {
     fetch('/statistics_data')
       .then(response => response.json())
       .then(data => {
-        $('#stats-today').html(listToHtml(data.today || []));
-        $('#stats-month').html(listToHtml(data.month || []));
-        $('#stats-year').html(listToHtml(data.year || []));
-        $('#stats-alltime').html(listToHtml(data.all || []));
+        $('#stats-today').html(groupToHtml(data.today));
+        $('#stats-month').html(groupToHtml(data.month));
+        $('#stats-year').html(groupToHtml(data.year));
+        $('#stats-alltime').html(groupToHtml(data.all));
       })
       .catch(err => {
         console.error('Error loading statistics', err);


### PR DESCRIPTION
## Summary
- rename the solar radiation energy label to "Сума от слънчева радиация"
- include the solar radiation energy entry in the right column ordering for all statistic views
- restructure the statistics API and layout into explicit left/right columns so the solar radiation sum renders beneath the radiation metric across all periods

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_68e37f82947c8328a4b4ed2a6d40806d